### PR TITLE
Add SMS Docker usage documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+__pycache__
+*.py[cod]
+*.egg-info
+.build
+.dist
+.tox
+docs
+tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+RUN pip install --no-cache-dir .
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 8000
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -132,6 +132,24 @@ Some code [examples](examples/) are in [/examples](examples/)  folder
 ### SMS
 
 * Relay received SMS into your email https://github.com/chenwei791129/Huawei-LTE-Router-SMS-to-E-mail-Sender
+* Basic SMS HTTP API [examples/sms_http_api.py](examples/sms_http_api.py)
+* Docker container for SMS API [Dockerfile](Dockerfile)
+* Step-by-step Docker guide [docs/sms-http-api-docker.md](docs/sms-http-api-docker.md)
+
+### Docker
+
+To run the SMS HTTP API in a container:
+
+```bash
+docker build -t sms-api .
+docker run \
+  -e MODEM_URL="http://192.168.8.1/" \
+  -e USERNAME=admin \
+  -e PASSWORD=PASSWORD \
+  -p 8000:8000 sms-api
+```
+
+See [docs/sms-http-api-docker.md](docs/sms-http-api-docker.md) for a detailed guide on running the container and sending your first SMS.
 
 ## Ports to other languages
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+HOST=${HOST:-0.0.0.0}
+PORT=${PORT:-8000}
+
+if [ -z "$MODEM_URL" ]; then
+    echo "MODEM_URL environment variable is required" >&2
+    exit 1
+fi
+
+CMD="python examples/sms_http_api.py $MODEM_URL --host $HOST --port $PORT"
+if [ -n "$USERNAME" ]; then
+    CMD="$CMD --username $USERNAME"
+fi
+if [ -n "$PASSWORD" ]; then
+    CMD="$CMD --password $PASSWORD"
+fi
+exec $CMD

--- a/docs/sms-http-api-docker.md
+++ b/docs/sms-http-api-docker.md
@@ -1,0 +1,49 @@
+# SMS HTTP API Docker Guide
+
+This guide explains how to build the Docker image for the example SMS HTTP API, run the container and send your first SMS.
+
+## Build the image
+
+```bash
+docker build -t sms-api .
+```
+
+This command creates an image containing the API server from `examples/sms_http_api.py`.
+
+## Run the container
+
+Set the environment variables for your modem connection and start the container:
+
+```bash
+docker run -d \
+  -e MODEM_URL="http://192.168.8.1/" \
+  -e USERNAME=admin \
+  -e PASSWORD=YOUR_PASSWORD \
+  -p 8000:8000 sms-api
+```
+
+`MODEM_URL` is required and should point to your Huawei modem. `USERNAME` and `PASSWORD` supply login credentials. You can optionally set `HOST` and `PORT` to change the listening address (default `0.0.0.0:8000`).
+
+The API server will now be reachable on the host at the chosen port.
+
+## Send your first SMS
+
+Prepare the JSON payload and use `curl` to call the API:
+
+```bash
+curl -X POST http://localhost:8000/sms \
+  -H "Content-Type: application/json" \
+  -d '{"to": ["+420123456789"], "text": "Hello from the API!"}'
+```
+
+If the request succeeds, the server responds with `OK`.
+
+## Alternative usage
+
+You can also run the API directly outside Docker using:
+
+```bash
+python examples/sms_http_api.py http://192.168.8.1/ --username admin --password YOUR_PASSWORD
+```
+
+See the script's docstring for additional options.

--- a/examples/sms_http_api.py
+++ b/examples/sms_http_api.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Expose a simple HTTP API for sending SMS messages.
+
+Example usage:
+python3 sms_http_api.py http://192.168.8.1/ \
+    --username admin --password PASSWORD \
+    --host 0.0.0.0 --port 8000
+# Then send SMS with curl:
+# curl -X POST -H "Content-Type: application/json" \
+#      -d '{"to": ["+420123456789"], "text": "Hello"}' http://0.0.0.0:8000/sms
+"""
+
+from argparse import ArgumentParser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+
+from huawei_lte_api.Connection import Connection
+from huawei_lte_api.Client import Client
+from huawei_lte_api.enums.client import ResponseEnum
+
+
+class SMSHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        if self.path != '/sms':
+            self.send_error(404, 'Not found')
+            return
+
+        content_length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(content_length)
+        try:
+            data = json.loads(body.decode('utf-8'))
+            recipients = data['to']
+            text = data['text']
+            if not isinstance(recipients, list) or not isinstance(text, str):
+                raise ValueError
+        except (ValueError, KeyError, json.JSONDecodeError):
+            self.send_error(400, 'Invalid JSON body')
+            return
+
+        try:
+            with Connection(self.server.modem_url, username=self.server.username,
+                            password=self.server.password) as connection:
+                client = Client(connection)
+                resp = client.sms.send_sms(recipients, text)
+            if resp == ResponseEnum.OK.value:
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b'OK')
+            else:
+                self.send_error(500, 'Failed to send SMS')
+        except Exception as exc:
+            self.send_error(500, str(exc))
+
+
+class SMSHTTPServer(HTTPServer):
+    def __init__(self, server_address, handler_class, modem_url, username, password):
+        super().__init__(server_address, handler_class)
+        self.modem_url = modem_url
+        self.username = username
+        self.password = password
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument('url', type=str)
+    parser.add_argument('--username', type=str)
+    parser.add_argument('--password', type=str)
+    parser.add_argument('--host', type=str, default='127.0.0.1')
+    parser.add_argument('--port', type=int, default=8000)
+    args = parser.parse_args()
+
+    server = SMSHTTPServer((args.host, args.port), SMSHandler, args.url,
+                           args.username, args.password)
+    print(f'Serving on {args.host}:{args.port}')
+    server.serve_forever()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- document running the SMS HTTP API in Docker in new guide
- link to the guide from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_687a618cfa34832297c74ec64ad5ad69