### PR TITLE
Add Rocky Linux install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,5 @@ Quelques [exemples](examples/) se trouvent dans le dossier [/examples](examples/
 
 Consultez [le journal des mises à jour](docs/mise-a-jour.md) pour connaître les dernières évolutions. Cette page est également accessible depuis le menu de l'interface web.
 
+Pour l'installation sur Rocky Linux, consultez [ce guide](docs/installation-rocky-linux.md).
+

--- a/docs/installation-rocky-linux.md
+++ b/docs/installation-rocky-linux.md
@@ -1,0 +1,47 @@
+# Installation on Rocky Linux
+
+## Prerequisites
+- Python 3 and pip
+- git
+- systemd (default on Rocky Linux)
+
+Install basic packages:
+```bash
+sudo dnf install -y python3 python3-virtualenv git
+```
+
+## Clone the repository
+```bash
+sudo git clone https://github.com/greglg45/bc-api-sms.git /data/bc-api-sms
+cd /data/bc-api-sms
+```
+
+## Set up the Python environment
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Sample `systemd` service
+Create `/etc/systemd/system/bc-api-sms.service` with the following content:
+```ini
+[Unit]
+Description=bc-api-sms HTTP API
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/data/bc-api-sms
+ExecStart=/data/bc-api-sms/venv/bin/python examples/sms_http_api.py
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Enable and start the service
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now bc-api-sms.service
+```


### PR DESCRIPTION
## Summary
- document installing on Rocky Linux
- reference the new installation guide from README
- correct repository URL in Rocky Linux guide
- clone to `/data/bc-api-sms`

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687cf89a3a9c83229b7d1627dd20b2f7