### PR TITLE
Update install script to setup virtualenv and service

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,9 +9,17 @@ REPO_URL="https://github.com/greglg45/bc-api-sms.git"
 INSTALL_DIR="/data/bc-api-sms"
 VERSION_FILE="$INSTALL_DIR/VERSION"
 
+# Parameters used for the HTTP API service
+ROUTER_URL="http://192.168.8.1/"
+ROUTER_USERNAME="admin"
+ROUTER_PASSWORD="password"
+HOST="0.0.0.0"
+PORT="80"
+
 # Install required packages if missing
 install_deps() {
-    local pkgs=(git python3 python3-pip)
+    # Python virtualenv is used to isolate dependencies
+    local pkgs=(git python3 python3-pip python3-virtualenv)
     for pkg in "${pkgs[@]}"; do
         if ! command -v ${pkg%%-*} >/dev/null 2>&1; then
             sudo dnf install -y "$pkg"
@@ -39,9 +47,45 @@ install_package() {
     sudo pip3 install --upgrade "$INSTALL_DIR"
 }
 
+# Create the virtual environment and install requirements
+setup_venv() {
+    # Create venv only if it does not already exist
+    if [ ! -d "$INSTALL_DIR/venv" ]; then
+        sudo python3 -m venv "$INSTALL_DIR/venv"
+    fi
+
+    # Activate the venv in a subshell to install dependencies
+    sudo bash -c "source '$INSTALL_DIR/venv/bin/activate' && pip install -r '$INSTALL_DIR/requirements.txt'"
+}
+
+# Create and enable the systemd service for the HTTP API
+setup_service() {
+    sudo tee /etc/systemd/system/bc-api-sms.service >/dev/null <<EOF
+[Unit]
+Description=bc-api-sms HTTP API
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=$INSTALL_DIR
+ExecStart=$INSTALL_DIR/venv/bin/python sms_http_api.py \
+    $ROUTER_URL --username $ROUTER_USERNAME --password $ROUTER_PASSWORD \
+    --host $HOST --port $PORT
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now bc-api-sms.service
+}
+
 main() {
     install_deps
     update_repo
+    # Ensure the Python environment is ready after updating the repository
+    setup_venv
 
     local repo_version=$(get_repo_version)
     local current_version=""
@@ -56,6 +100,9 @@ main() {
     else
         echo "Version $repo_version already installed" >&2
     fi
+
+    # Write and enable the systemd service on every run
+    setup_service
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- install python3-virtualenv
- create virtual environment and install requirements
- configure bc-api-sms systemd service

## Testing
- `bash -n install.sh`

------
https://chatgpt.com/codex/tasks/task_b_687d15a767148322ad61164d285fc8eb