### PR TITLE
Fix pip install command to use PIP_CERT

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -55,7 +55,8 @@ setup_venv() {
     fi
 
     # Activate the venv in a subshell to install dependencies
-    sudo bash -c "source '$INSTALL_DIR/venv/bin/activate' && pip install -r '$INSTALL_DIR/requirements.txt'"
+    sudo -E bash -c "source '$INSTALL_DIR/venv/bin/activate' && \
+        pip install --cert \"$PIP_CERT\" -r '$INSTALL_DIR/requirements.txt'"
 }
 
 # Create and enable the systemd service for the HTTP API


### PR DESCRIPTION
## Summary
- activate sudo environment with `-E` in install script
- forward `$PIP_CERT` when installing requirements in the virtualenv

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687d5bab29808322aa42c7aaa3e848fe