### PR TITLE
Add API key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Quelques [exemples](examples/) se trouvent dans le dossier [/examples](examples/
 
 * Relayer les SMS reçus vers votre e-mail https://github.com/chenwei791129/Huawei-LTE-Router-SMS-to-E-mail-Sender
 * API HTTP SMS basique [sms_http_api.py](sms_http_api.py) (journalise les requêtes dans SQLite)
+  * option `--api-key` pour protéger l'envoi de SMS via l'en-tête `X-API-KEY`
   * inclut maintenant un endpoint `/health` renvoyant les informations du modem (dérivées de `device_info.py` et `device_signal.py`)
 
 ## Mises à jour

--- a/docs/installation-rocky-linux.md
+++ b/docs/installation-rocky-linux.md
@@ -37,7 +37,7 @@ WorkingDirectory=/data/bc-api-sms
 # Adjust the URL and credentials for your router
 ExecStart=/data/bc-api-sms/venv/bin/python sms_http_api.py \
     http://192.168.8.1/ --username admin --password <PASSWORD> \
-    --host 0.0.0.0 --port 80
+    --host 0.0.0.0 --port 80 --api-key <CLEF>
 
 Restart=on-failure
 

--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,7 @@
 Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **21 juillet 2025** : ajout de l'option `--api-key` pour sécuriser l'envoi de SMS via l'en-tête `X-API-KEY`.
 - **20 juillet 2025** : ajout d'une pastille indiquant le nombre de SMS reçus dans le menu.
 - **20 juillet 2025** : ajout d'une page de documentation de l'API.
 - **20 juillet 2025** : ajout de l'endpoint `/readsms` et possibilité de supprimer des SMS.


### PR DESCRIPTION
## Summary
- require `X-API-KEY` header when configured
- add new `--api-key` option and server attribute
- document API key usage in README and install guide
- update change log

## Testing
- `tox -e py311 -q` *(fails: file or directory not found: tests)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687decf4f33483229c837dc441ae12df