### PR TITLE
Add API key prompt to installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Quelques [exemples](examples/) se trouvent dans le dossier [/examples](examples/
 
 * Relayer les SMS reçus vers votre e-mail https://github.com/chenwei791129/Huawei-LTE-Router-SMS-to-E-mail-Sender
 * API HTTP SMS basique [sms_http_api.py](sms_http_api.py) (journalise les requêtes dans SQLite)
+  * option `--api-key` pour protéger l'envoi de SMS via l'en-tête `X-API-KEY`
   * inclut maintenant un endpoint `/health` renvoyant les informations du modem (dérivées de `device_info.py` et `device_signal.py`)
 
 ## Mises à jour

--- a/docs/installation-rocky-linux.md
+++ b/docs/installation-rocky-linux.md
@@ -37,7 +37,7 @@ WorkingDirectory=/data/bc-api-sms
 # Adjust the URL and credentials for your router
 ExecStart=/data/bc-api-sms/venv/bin/python sms_http_api.py \
     http://192.168.8.1/ --username admin --password <PASSWORD> \
-    --host 0.0.0.0 --port 80
+    --host 0.0.0.0 --port 80 --api-key <CLEF>
 
 Restart=on-failure
 

--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,7 @@
 Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **21 juillet 2025** : ajout de l'option `--api-key` pour sécuriser l'envoi de SMS via l'en-tête `X-API-KEY`.
 - **20 juillet 2025** : ajout d'une pastille indiquant le nombre de SMS reçus dans le menu.
 - **20 juillet 2025** : ajout d'une page de documentation de l'API.
 - **20 juillet 2025** : ajout de l'endpoint `/readsms` et possibilité de supprimer des SMS.

--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,7 @@ ROUTER_USERNAME="admin"
 ROUTER_PASSWORD="password"
 HOST="0.0.0.0"
 PORT="80"
+API_KEY=""
 
 # Install required packages if missing
 install_deps() {
@@ -102,6 +103,10 @@ setup_venv() {
 
 # Create and enable the systemd service for the HTTP API
 setup_service() {
+    local api_key_arg=""
+    if [ -n "$API_KEY" ]; then
+        api_key_arg=" --api-key $API_KEY"
+    fi
     sudo tee /etc/systemd/system/bc-api-sms.service >/dev/null <<EOF
 [Unit]
 Description=bc-api-sms HTTP API
@@ -112,7 +117,7 @@ Type=simple
 WorkingDirectory=$INSTALL_DIR
 ExecStart=$INSTALL_DIR/venv/bin/python sms_http_api.py \
     $ROUTER_URL --username $ROUTER_USERNAME --password $ROUTER_PASSWORD \
-    --host $HOST --port $PORT
+    --host $HOST --port $PORT$api_key_arg
 Restart=on-failure
 
 [Install]
@@ -132,6 +137,7 @@ main() {
     prompt_password_var ROUTER_PASSWORD "Router password" "$ROUTER_PASSWORD"
     prompt_var HOST "HTTP API host" "$HOST"
     prompt_var PORT "HTTP API port" "$PORT"
+    prompt_var API_KEY "API key (blank to disable)" "$API_KEY"
 
     install_deps
     stop_service


### PR DESCRIPTION
## Summary
- prompt for API key during installation
- append `--api-key` option in generated service

## Testing
- `pytest -q`
- `tox -e py311 -q` *(fails: file or directory not found: tests)*

------
https://chatgpt.com/codex/tasks/task_b_687decf4f33483229c837dc441ae12df