### PR TITLE
Add X-API-KEY field for test SMS

### DIFF
--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,7 @@
 Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **21 juillet 2025** : ajout d'un champ pour saisir la clef `X-API-KEY` dans la page "Test SMS".
 - **21 juillet 2025** : ajout de l'option `--api-key` pour sécuriser l'envoi de SMS via l'en-tête `X-API-KEY`.
 - **20 juillet 2025** : ajout d'une pastille indiquant le nombre de SMS reçus dans le menu.
 - **20 juillet 2025** : ajout d'une page de documentation de l'API.

--- a/sms_http_api.py
+++ b/sms_http_api.py
@@ -470,10 +470,15 @@ class SMSHandler(BaseHTTPRequestHandler):
                         .map(t => t.trim())
                         .filter(t => t);
                     const text = document.getElementById('text').value;
+                    const apiKey = document.getElementById('apiKey').value.trim();
                     const payload = {to: to, from: 'test api web', text: text};
+                    const headers = {'Content-Type': 'application/json'};
+                    if (apiKey) {
+                        headers['X-API-KEY'] = apiKey;
+                    }
                     const resp = await fetch('/sms', {
                         method: 'POST',
-                        headers: {'Content-Type': 'application/json'},
+                        headers: headers,
                         body: JSON.stringify(payload)
                     });
                     if (resp.ok) {
@@ -499,6 +504,10 @@ class SMSHandler(BaseHTTPRequestHandler):
                 <div class='mb-3'>
                     <label for='text' class='form-label'>Message</label>
                     <textarea id='text' class='form-control' rows='4' required></textarea>
+                </div>
+                <div class='mb-3'>
+                    <label for='apiKey' class='form-label'>Clé X-API-KEY</label>
+                    <input type='text' id='apiKey' class='form-control'>
                 </div>
                 <button type='submit' class='btn btn-company'>Envoyer</button>
             </form>


### PR DESCRIPTION
## Summary
- add input for API key on test SMS page
- send X-API-KEY header when provided
- record change in update log

## Testing
- `tox -e py311 -q` *(fails: tests not found)*
- `tox -e lint -q` *(fails: mypy errors)*

------
https://chatgpt.com/codex/tasks/task_b_687df8b857508322a200e8e359e7a38a