### PR TITLE
Add HTTPS prompts to installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Quelques [exemples](examples/) se trouvent dans le dossier [/examples](examples/
 * Relayer les SMS reçus vers votre e-mail https://github.com/chenwei791129/Huawei-LTE-Router-SMS-to-E-mail-Sender
 * API HTTP SMS basique [sms_http_api.py](sms_http_api.py) (journalise les requêtes dans SQLite)
   * option `--api-key` pour protéger l'envoi de SMS via l'en-tête `X-API-KEY`
+  * options `--certfile`/`--keyfile` pour activer HTTPS
   * inclut maintenant un endpoint `/health` renvoyant les informations du modem (dérivées de `device_info.py` et `device_signal.py`)
 
 ## Mises à jour
@@ -142,4 +143,5 @@ Quelques [exemples](examples/) se trouvent dans le dossier [/examples](examples/
 Consultez [le journal des mises à jour](docs/mise-a-jour.md) pour connaître les dernières évolutions. Cette page est également accessible depuis le menu de l'interface web.
 
 Pour l'installation sur Rocky Linux, consultez [ce guide](docs/installation-rocky-linux.md).
+Un script `install.sh` est également fourni pour automatiser le déploiement ; il vous demandera notamment les chemins du certificat et de la clé privée si vous souhaitez activer HTTPS.
 

--- a/docs/installation-rocky-linux.md
+++ b/docs/installation-rocky-linux.md
@@ -16,6 +16,12 @@ sudo git clone https://github.com/greglg45/bc-api-sms.git /data/bc-api-sms
 cd /data/bc-api-sms
 ```
 
+### Automated installation
+
+An `install.sh` helper script is provided to perform these steps automatically.
+Run it as root and follow the prompts. The script now asks for the TLS certificate
+and key so the service can be served over HTTPS.
+
 ## Set up the Python environment
 ```bash
 python3 -m venv venv

--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,8 @@ ROUTER_PASSWORD="password"
 HOST="0.0.0.0"
 PORT="80"
 API_KEY=""
+CERTFILE=""
+KEYFILE=""
 
 # Install required packages if missing
 install_deps() {
@@ -115,6 +117,10 @@ setup_service() {
     if [ -n "$API_KEY" ]; then
         api_key_arg=" --api-key $API_KEY"
     fi
+    local https_args=""
+    if [ -n "$CERTFILE" ] && [ -n "$KEYFILE" ]; then
+        https_args=" --certfile $CERTFILE --keyfile $KEYFILE"
+    fi
     sudo tee /etc/systemd/system/bc-api-sms.service >/dev/null <<EOF
 [Unit]
 Description=bc-api-sms HTTP API
@@ -125,7 +131,7 @@ Type=simple
 WorkingDirectory=$INSTALL_DIR
 ExecStart=$INSTALL_DIR/venv/bin/python sms_http_api.py \
     $ROUTER_URL --username $ROUTER_USERNAME --password $ROUTER_PASSWORD \
-    --host $HOST --port $PORT$api_key_arg
+    --host $HOST --port $PORT$api_key_arg$https_args
 Restart=on-failure
 
 [Install]
@@ -146,6 +152,8 @@ main() {
     prompt_var HOST "HTTP API host" "$HOST"
     prompt_var PORT "HTTP API port" "$PORT"
     prompt_var API_KEY "API key (blank to disable)" "$API_KEY"
+    prompt_var CERTFILE "TLS certificate file (blank to disable HTTPS)" "$CERTFILE"
+    prompt_var KEYFILE "TLS private key file" "$KEYFILE"
 
     install_deps
     stop_service

--- a/sms_http_api.py
+++ b/sms_http_api.py
@@ -803,6 +803,16 @@ def main():
         default=os.getenv("SMS_API_KEY"),
         help="Clé API requise dans l'en-tête X-API-KEY pour POST /sms",
     )
+    parser.add_argument(
+        "--certfile",
+        type=str,
+        help="Chemin du certificat TLS (active HTTPS s'il est fourni)",
+    )
+    parser.add_argument(
+        "--keyfile",
+        type=str,
+        help="Chemin de la clé privée TLS",
+    )
 
     args = parser.parse_args()
 
@@ -816,7 +826,17 @@ def main():
         api_key=args.api_key,
     )
 
-    print(f"Serving on {args.host}:{args.port}")
+    if args.certfile and args.keyfile:
+        import ssl
+
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(certfile=args.certfile, keyfile=args.keyfile)
+        server.socket = context.wrap_socket(server.socket, server_side=True)
+        protocol = "https"
+    else:
+        protocol = "http"
+
+    print(f"Serving on {protocol}://{args.host}:{args.port}")
     server.serve_forever()
 
 


### PR DESCRIPTION
## Summary
- ask for certificate and key in install.sh
- mention install.sh in README and Rocky Linux guide

## Testing
- `pytest -q`
- `python -m py_compile sms_http_api.py`


------
https://chatgpt.com/codex/tasks/task_b_687e32f8f3a483229247bb8033d2e58d