### PR TITLE
Fix missing virtualenv package error

### DIFF
--- a/docs/installation-rocky-linux.md
+++ b/docs/installation-rocky-linux.md
@@ -7,8 +7,12 @@
 
 Install basic packages:
 ```bash
-sudo dnf install -y python3 python3-virtualenv git
+sudo dnf install -y python3 git
 ```
+
+Python 3 on Rocky Linux 9 includes the ``venv`` module used to create
+virtual environments, so no separate ``python3-virtualenv`` package is
+required.
 
 ## Clone the repository
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,7 @@ KEYFILE=""
 # Install required packages if missing
 install_deps() {
     # Python virtualenv is used to isolate dependencies
-    local pkgs=(git python3 python3-pip python-pip python3-virtualenv policycoreutils-python-utils)
+    local pkgs=(git python3 python3-pip python-pip policycoreutils-python-utils)
     sudo dnf install -y "${pkgs[@]}"
 }
 


### PR DESCRIPTION
## Summary
- remove unused `python3-virtualenv` package from install deps
- update Rocky Linux instructions accordingly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687e38efccd8832294991ce61c14d7b2