### PR TITLE
Fix missing repo in installer

### DIFF
--- a/docs/installation-rocky-linux.md
+++ b/docs/installation-rocky-linux.md
@@ -7,8 +7,12 @@
 
 Install basic packages:
 ```bash
-sudo dnf install -y python3 python3-virtualenv git
+sudo dnf install -y python3 git
 ```
+
+Python 3 on Rocky Linux 9 includes the ``venv`` module used to create
+virtual environments, so no separate ``python3-virtualenv`` package is
+required.
 
 ## Clone the repository
 ```bash
@@ -20,7 +24,9 @@ cd /data/bc-api-sms
 
 An `install.sh` helper script is provided to perform these steps automatically.
 Run it as root and follow the prompts. The script now asks for the TLS certificate
-and key so the service can be served over HTTPS.
+and key so the service can be served over HTTPS. It will also clone the
+repository if needed and recreate the target directory should it not already
+contain a valid Git checkout.
 
 ## Set up the Python environment
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,7 @@ KEYFILE=""
 # Install required packages if missing
 install_deps() {
     # Python virtualenv is used to isolate dependencies
-    local pkgs=(git python3 python3-pip python-pip python3-virtualenv policycoreutils-python-utils)
+    local pkgs=(git python3 python3-pip python-pip policycoreutils-python-utils)
     sudo dnf install -y "${pkgs[@]}"
 }
 
@@ -68,9 +68,13 @@ stop_service() {
 update_repo() {
     if [ ! -d "$INSTALL_DIR" ]; then
         sudo git clone "$REPO_URL" "$INSTALL_DIR"
-    else
+    elif [ -d "$INSTALL_DIR/.git" ]; then
         sudo git -C "$INSTALL_DIR" fetch --tags
         sudo git -C "$INSTALL_DIR" pull --ff-only
+    else
+        echo "Directory $INSTALL_DIR exists but is not a git repository; re-cloning" >&2
+        sudo rm -rf "$INSTALL_DIR"
+        sudo git clone "$REPO_URL" "$INSTALL_DIR"
     fi
 }
 


### PR DESCRIPTION
## Summary
- handle case where install dir exists but is not a git repository
- document that install.sh re-clones when necessary

## Testing
- `bash -n install.sh`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_687e38efccd8832294991ce61c14d7b2