### PR TITLE
Fix install.sh when run from install dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,8 +73,15 @@ update_repo() {
         sudo git -C "$INSTALL_DIR" pull --ff-only
     else
         echo "Directory $INSTALL_DIR exists but is not a git repository; re-cloning" >&2
+        local current_dir="$(pwd -P)"
+        if [ "$current_dir" = "$(realpath "$INSTALL_DIR")" ]; then
+            cd /tmp
+        fi
         sudo rm -rf "$INSTALL_DIR"
         sudo git clone "$REPO_URL" "$INSTALL_DIR"
+        if [ "$current_dir" = "$(realpath "$INSTALL_DIR")" ]; then
+            cd "$INSTALL_DIR"
+        fi
     fi
 }
 


### PR DESCRIPTION
## Summary
- avoid removing the working directory while re-cloning in `install.sh`

## Testing
- `pip install -e .`
- `pytest -q`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_b_687e3c21e96083228697a1ba818c217c