### PR TITLE
Sécurisation affichage HTML

### DIFF
--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,7 @@
 Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **21 juillet 2025** : sécurisation de l'affichage HTML des SMS dans les pages `logs` et `readsms`.
 - **21 juillet 2025** : refonte en modules (`sms_api`) et simplification de `sms_http_api.py`.
 - **21 juillet 2025** : ajout d'un champ pour saisir la clef `X-API-KEY` dans la page "Test SMS".
 - **21 juillet 2025** : ajout de l'option `--api-key` pour sécuriser l'envoi de SMS via l'en-tête `X-API-KEY`.

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -3,6 +3,7 @@ import os
 import sqlite3
 import urllib.parse
 from http.server import BaseHTTPRequestHandler
+import html
 
 from huawei_lte_api.Connection import Connection
 from huawei_lte_api.Client import Client
@@ -263,7 +264,17 @@ class SMSHandler(BaseHTTPRequestHandler):
         ]
         for row in rows:
             html.append(
-                f"<tr><td><input type='checkbox' class='rowchk' name='ids' value='{row['id']}'></td><td>{row['timestamp']}</td><td>{row['sender'] or ''}</td><td>{row['phone']}</td><td>{row['message']}</td><td>{row['response']}</td></tr>"
+                (
+                    "<tr>"
+                    "<td><input type='checkbox' class='rowchk' name='ids' value='"
+                    f"{row['id']}'></td>"
+                    f"<td>{html.escape(row['timestamp'])}</td>"
+                    f"<td>{html.escape(row['sender'] or '')}</td>"
+                    f"<td>{html.escape(row['phone'])}</td>"
+                    f"<td>{html.escape(row['message'])}</td>"
+                    f"<td>{html.escape(row['response'])}</td>"
+                    "</tr>"
+                )
             )
         html.extend(
             [
@@ -329,7 +340,15 @@ class SMSHandler(BaseHTTPRequestHandler):
         ]
         for m in messages:
             html.append(
-                f"<tr><td><input type='checkbox' class='rowchk' name='ids' value='{m['Index']}'></td><td>{m['Date']}</td><td>{m['Phone']}</td><td>{m['Content']}</td></tr>"
+                (
+                    "<tr>"
+                    "<td><input type='checkbox' class='rowchk' name='ids' value='"
+                    f"{m['Index']}'></td>"
+                    f"<td>{html.escape(m['Date'])}</td>"
+                    f"<td>{html.escape(m['Phone'])}</td>"
+                    f"<td>{html.escape(m['Content'])}</td>"
+                    "</tr>"
+                )
             )
         html.extend([
             "</table>",


### PR DESCRIPTION
## Résumé
- échappe les champs provenant de l'utilisateur dans `_serve_logs` et `_serve_readsms`
- mention de la mise à jour dans `docs/mise-a-jour.md`

## Test
- `python sms_http_api.py http://localhost --host 127.0.0.1 --port 8000 --db test.db` (échec de connexion modem mais pages servies)
- `curl http://127.0.0.1:8000/logs`
- `curl http://127.0.0.1:8000/readsms`


------
https://chatgpt.com/codex/tasks/task_b_687eb0c74cf08322952a6d47c569d840