### PR TITLE
Ajout du thème sombre

### DIFF
--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,7 @@
 Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **22 juillet 2025** : ajout d'un bouton pour passer du thème clair au thème sombre.
 - **21 juillet 2025** : sécurisation de l'affichage HTML des SMS dans les pages `logs` et `readsms`.
 - **21 juillet 2025** : refonte en modules (`sms_api`) et simplification de `sms_http_api.py`.
 - **21 juillet 2025** : ajout d'un champ pour saisir la clef `X-API-KEY` dans la page "Test SMS".

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -62,6 +62,7 @@ NAVBAR_TEMPLATE = """
           <span class='navbar-toggler-icon'></span>
         </button>
         <span class='navbar-brand ms-2'>API SMS BC</span>
+        <button id='themeToggle' class='btn btn-link text-light ms-auto' onclick='toggleTheme()'>🌙</button>
       </div>
     </nav>
     <div class='offcanvas offcanvas-start' tabindex='-1' id='menu'>
@@ -137,6 +138,9 @@ class SMSHandler(BaseHTTPRequestHandler):
         if self.path == "/updates":
             self._serve_updates()
             return
+        if self.path == "/theme.js":
+            self._serve_js()
+            return
         if self.path == "/baudin.css":
             self._serve_css()
             return
@@ -200,6 +204,7 @@ class SMSHandler(BaseHTTPRequestHandler):
             <link rel='stylesheet' href='baudin.css'>
 
             <script src='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js'></script>
+            <script src='theme.js'></script>
             <style>
                 .bg-company {background-color:#0060ac;}
                 .btn-company {background-color:#0060ac;border-color:#0060ac;}
@@ -250,6 +255,7 @@ class SMSHandler(BaseHTTPRequestHandler):
             "<link rel='stylesheet' href='baudin.css'>",
 
             "<script src='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js'></script>",
+            "<script src='theme.js'></script>",
             "<style>.bg-company{background-color:#0060ac;}.btn-company{background-color:#0060ac;border-color:#0060ac;}.text-company{color:#0060ac;}</style>",
             "<script>function selectAll(){document.querySelectorAll('.rowchk').forEach(c=>c.checked=true);}</script>",
             "</head><body class='container-fluid px-3 py-4'>",
@@ -324,6 +330,7 @@ class SMSHandler(BaseHTTPRequestHandler):
             "<link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css'>",
             "<link rel='stylesheet' href='baudin.css'>",
             "<script src='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js'></script>",
+            "<script src='theme.js'></script>",
             "<style>.bg-company{background-color:#0060ac;}.btn-company{background-color:#0060ac;border-color:#0060ac;}.text-company{color:#0060ac;}</style>",
 
             "<script>function selectAll(){document.querySelectorAll('.rowchk').forEach(c=>c.checked=true);}</script>",
@@ -374,6 +381,7 @@ class SMSHandler(BaseHTTPRequestHandler):
             <link rel='stylesheet' href='baudin.css'>
 
             <script src='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js'></script>
+            <script src='theme.js'></script>
             <style>
                 .bg-company {background-color:#0060ac;}
                 .btn-company {background-color:#0060ac;border-color:#0060ac;}
@@ -450,6 +458,7 @@ class SMSHandler(BaseHTTPRequestHandler):
             <link rel='stylesheet' href='baudin.css'>
 
             <script src='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js'></script>
+            <script src='theme.js'></script>
             <style>
                 .bg-company {background-color:#0060ac;}
                 .btn-company {background-color:#0060ac;border-color:#0060ac;}
@@ -532,6 +541,7 @@ class SMSHandler(BaseHTTPRequestHandler):
                       "<link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css'>",
                       "<link rel='stylesheet' href='baudin.css'>",
                       "<script src='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js'></script>",
+                      "<script src='theme.js'></script>",
                       "<style>.bg-company{background-color:#0060ac;}.btn-company{background-color:#0060ac;border-color:#0060ac;}.text-company{color:#0060ac;}</style>",
                       "</head><body class='container-fluid px-3 py-4'>",
                       "{NAVBAR}",
@@ -583,6 +593,19 @@ class SMSHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(css)
 
+    def _serve_js(self):
+        path = os.path.join(os.path.dirname(__file__), os.pardir, 'theme.js')
+        try:
+            with open(path, 'rb') as f:
+                js = f.read()
+        except Exception:
+            js = b''
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/javascript')
+        self.send_header('Content-Length', str(len(js)))
+        self.end_headers()
+        self.wfile.write(js)
+
     def _serve_openapi_json(self):
         try:
             with open(OPENAPI_PATH, 'rb') as f:
@@ -605,6 +628,7 @@ class SMSHandler(BaseHTTPRequestHandler):
             <link rel='stylesheet' href='baudin.css'>
             <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css'>
             <script src='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js'></script>
+            <script src='theme.js'></script>
             <script src='https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.js'></script>
             <style>.bg-company{{background-color:#0060ac;}}</style>
         </head>

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,24 @@
+(function(){
+  function applyTheme(theme){
+    document.documentElement.setAttribute('data-bs-theme', theme);
+    var btn = document.getElementById('themeToggle');
+    if(btn){
+      btn.textContent = theme === 'dark' ? '☀' : '🌙';
+    }
+  }
+  function init(){
+    var stored = localStorage.getItem('theme');
+    if(stored){
+      applyTheme(stored);
+    } else if(window.matchMedia('(prefers-color-scheme: dark)').matches){
+      applyTheme('dark');
+    }
+  }
+  window.toggleTheme = function(){
+    var current = document.documentElement.getAttribute('data-bs-theme') === 'dark' ? 'dark' : 'light';
+    var next = current === 'dark' ? 'light' : 'dark';
+    localStorage.setItem('theme', next);
+    applyTheme(next);
+  };
+  window.addEventListener('DOMContentLoaded', init);
+})();


### PR DESCRIPTION
## Summary
- permettre le changement de thème clair/sombre
- servir un script `theme.js`
- consigner la mise à jour dans `docs/mise-a-jour.md`

## Testing
- `python -m py_compile sms_api/handler.py sms_api/server.py sms_api/utils.py`
- `flake8 sms_api/handler.py` *(échoue: F401, F811, E501, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_687eb2b0f1e083229ff3422e499bd8d8