### PR TITLE
Ajout du schéma X-API-KEY dans l'OpenAPI

### DIFF
--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,7 @@
 Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **25 juillet 2025** : ajout du schéma de sécurité `X-API-KEY` dans `openapi.json` et association à l'opération POST `/sms`.
 - **24 juillet 2025** : correction d'une régression provoquant une erreur sur la page `/logs`.
 - **23 juillet 2025** : correction de la page `/logs` qui retournait `404` avec
   un slash final ou des paramètres dans l'URL.

--- a/openapi.json
+++ b/openapi.json
@@ -73,7 +73,12 @@
           "500": {
             "description": "Failed to send SMS"
           }
-        }
+        },
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ]
       }
     },
     "/health": {
@@ -209,6 +214,15 @@
             "description": "Redirect to /logs"
           }
         }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-KEY"
       }
     }
   }


### PR DESCRIPTION
## Résumé
- déclare la clé `X-API-KEY` dans `openapi.json`
- applique ce mécanisme de sécurité au POST `/sms`
- documente la mise à jour dans `docs/mise-a-jour.md`

## Tests
- `pytest -q`
- `tox -qq` *(échoue : tests manquants)*

------
https://chatgpt.com/codex/tasks/task_b_687f43d28ec883228319ceefab37cdb4