### PR TITLE
Mettre en avant X-API-KEY dans Swagger

### DIFF
--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -4,6 +4,7 @@ Cette page recense les évolutions majeures de l'application. Elle doit être mi
 
 ## Historique
 
+- **27 juillet 2025** : ajout d'un message dans Swagger UI précisant l'en-tête `X-API-KEY` requis pour POST `/sms`.
 - **26 juillet 2025** : la page Swagger indique désormais l'en-tête `X-API-KEY` requis pour l'opération POST `/sms`.
 - **25 juillet 2025** : ajout du schéma de sécurité `X-API-KEY` dans `openapi.json` et association à l'opération POST `/sms`.
 - **24 juillet 2025** : correction d'une régression provoquant une erreur sur la page `/logs`.

--- a/openapi.json
+++ b/openapi.json
@@ -222,7 +222,8 @@
       "apiKeyAuth": {
         "type": "apiKey",
         "in": "header",
-        "name": "X-API-KEY"
+        "name": "X-API-KEY",
+        "description": "Clé API requise dans l'en-tête X-API-KEY"
       }
     }
   }

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -636,6 +636,7 @@ class SMSHandler(BaseHTTPRequestHandler):
         </head>
         <body class='container-fluid px-3 py-4'>
             {self._navbar_html()}
+            <p class='mt-3'>L'en-tête <code>X-API-KEY</code> est requis pour l'opération POST <code>/sms</code>.</p>
             <div id='swagger-ui'></div>
             <script>
             window.onload = function() {{


### PR DESCRIPTION
## Summary
- afficher un message dans la page Swagger pour rappeler le header `X-API-KEY`
- préciser la description du schéma `apiKeyAuth` dans `openapi.json`
- consigner cette évolution dans le journal des mises à jour

## Testing
- `python -m compileall -q sms_api`
- `python -m py_compile sms_http_api.py`
- `python -m json.tool openapi.json >/dev/null`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687f7146c1fc83229932b2453521d6e9