### PR TITLE
Ajout page d'administration

### DIFF
--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -4,6 +4,8 @@ Cette page recense les évolutions majeures de l'application. Elle doit être mi
 
 ## Historique
 
+- **28 juillet 2025** : ajout d'une interface d'administration pour modifier la configuration, redémarrer le service et suivre les logs en direct.
+
 - **27 juillet 2025** : ajout d'un message dans Swagger UI précisant l'en-tête `X-API-KEY` requis pour POST `/sms`.
 - **26 juillet 2025** : la page Swagger indique désormais l'en-tête `X-API-KEY` requis pour l'opération POST `/sms`.
 - **25 juillet 2025** : ajout du schéma de sécurité `X-API-KEY` dans `openapi.json` et association à l'opération POST `/sms`.

--- a/sms_api/server.py
+++ b/sms_api/server.py
@@ -11,6 +11,9 @@ class SMSHTTPServer(HTTPServer):
         password,
         db_path,
         api_key=None,
+        certfile=None,
+        keyfile=None,
+        config_path="config.json",
     ):
         super().__init__(server_address, handler_class)
         self.modem_url = modem_url
@@ -18,5 +21,16 @@ class SMSHTTPServer(HTTPServer):
         self.password = password
         self.db_path = db_path
         self.api_key = api_key
+        self.certfile = certfile
+        self.keyfile = keyfile
+        self.config_path = config_path
+
+    def restart(self):
+        """Redémarre le processus."""
+        import os
+        import sys
+
+        os.execv(sys.executable, [sys.executable] + sys.argv)
+
 
 __all__ = ["SMSHTTPServer"]


### PR DESCRIPTION
## Résumé
- interface d'administration pour modifier la configuration du modem et les certificats
- possibilité de redémarrer le service et de suivre les logs en direct
- chargement d'une configuration `config.json` au démarrage
- mise à jour du journal des évolutions

## Tests
- `python -m compileall -q sms_api sms_http_api.py`
- `flake8 sms_api sms_http_api.py`


------
https://chatgpt.com/codex/tasks/task_b_687ff44bc0848322bf4486a50be67d8e