### PR TITLE
Correctif redémarrage service

### DIFF
--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -13,6 +13,7 @@ Cette page recense les évolutions majeures de l'application. Elle doit être mi
 - **25 juillet 2025** : ajout du schéma de sécurité `X-API-KEY` dans `openapi.json` et association à l'opération POST `/sms`.
 - **24 juillet 2025** : correction d'une régression provoquant une erreur sur la page `/logs`.
 - **23 juillet 2025** : correction de la page `/logs` qui retournait `404` avec un slash final ou des paramètres dans l'URL.
+- **23 juillet 2025** : correction du mécanisme de redémarrage du service.
 - **22 juillet 2025** : ajout d'un tableau de bord sur la page principale affichant le nombre de SMS envoyés et rȩus ainsi que le dernier expéditeur.
 - **22 juillet 2025** : ajout d'un bouton pour passer du thème clair au thème sombre.
 - **21 juillet 2025** : sécurisation de l'affichage HTML des SMS dans les pages `logs` et `readsms`.

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -621,7 +621,11 @@ class SMSHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.end_headers()
         self.wfile.write(b'Redemarrage...')
-        threading.Thread(target=self.server.restart, daemon=True).start()
+        try:
+            self.wfile.flush()
+        except Exception:
+            pass
+        self.server.restart()
 
     def _serve_docs(self):
         html = """

--- a/sms_api/server.py
+++ b/sms_api/server.py
@@ -1,4 +1,8 @@
 from http.server import HTTPServer
+import os
+import sys
+import subprocess
+import shutil
 
 
 class SMSHTTPServer(HTTPServer):
@@ -28,11 +32,11 @@ class SMSHTTPServer(HTTPServer):
         self.timeout = timeout
 
     def restart(self):
-        """Redémarre le processus."""
-        import os
-        import sys
-
-        os.execv(sys.executable, [sys.executable] + sys.argv)
+        """Redémarre le service ou le processus."""
+        if shutil.which("systemctl"):
+            subprocess.run(["systemctl", "restart", "bc-api-sms.service"])
+        else:
+            os.execv(sys.executable, [sys.executable] + sys.argv)
 
 
 __all__ = ["SMSHTTPServer"]


### PR DESCRIPTION
## Résumé
- améliore `restart` dans `SMSHTTPServer` pour utiliser `systemctl` si disponible
- appelle `SMSHTTPServer.restart` sans thread et flush de la réponse
- note de mise à jour

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880a2b61e2883228855f88caaceec6d