### PR TITLE
Affichage des informations réseau

### DIFF
--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,7 @@
 Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **1 août 2025** : ajout sur la page principale d'une case affichant les informations réseau (opérateur, type et barres de signal).
 - **31 juillet 2025** : le script `install.sh` conserve désormais les paramètres
   saisis lors d'une précédente installation.
 - **30 juillet 2025** : suppression de la fonctionnalité de logs en direct.

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -275,6 +275,8 @@ class SMSHandler(BaseHTTPRequestHandler):
                     document.getElementById('sentCount').textContent = dashboard.sent_total;
                     document.getElementById('receivedCount').textContent = dashboard.received_total;
                     document.getElementById('lastSender').textContent = dashboard.last_sender || 'N/A';
+                    const networkInfo = `${health.operator_name.toUpperCase()} ${health.network_type} ${health.signal_bars}`;
+                    document.getElementById('networkInfo').textContent = networkInfo;
                 }
                 window.onload = loadData;
             </script>
@@ -292,6 +294,9 @@ class SMSHandler(BaseHTTPRequestHandler):
                     </div>
                     <div class='col'>
                         <div class='p-3 bg-light rounded'>Dernier expéditeur : <span id='lastSender'>-</span></div>
+                    </div>
+                    <div class='col'>
+                        <div class='p-3 bg-light rounded'>Réseau : <span id='networkInfo'>-</span></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Résumé
- ajout d'une quatrième case sur la page principale pour afficher l'opérateur, le type de réseau et les barres de signal
- mise à jour du journal des mises à jour

## Tests
- `python -m py_compile sms_api/handler.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880af91718483229a1705930a90b7fa