### PR TITLE
Ajout script de mise à jour

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Procédure de contribution
+
+Merci de proposer vos améliorations via des pull requests.
+
+1. Forkez le dépôt et créez votre branche.
+2. Une fois vos modifications réalisées, exécutez les tests avec `pytest`.
+3. Ajoutez une entrée dans `docs/mise-a-jour.md` grâce au script :
+   ```bash
+   python scripts/ajout_mise_a_jour.py "Description succincte de la modification"
+   ```
+4. Commitez le fichier `docs/mise-a-jour.md` modifié avec le reste de vos changements.
+5. Soumettez ensuite votre pull request.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ Quelques [exemples](examples/) se trouvent dans le dossier [/examples](examples/
 ## Mises à jour
 
 Consultez [le journal des mises à jour](docs/mise-a-jour.md) pour connaître les dernières évolutions. Cette page est également accessible depuis le menu de l'interface web.
+Pour ajouter une entrée, utilisez le script `scripts/ajout_mise_a_jour.py` :
+
+```bash
+python scripts/ajout_mise_a_jour.py "Votre message"
+```
+
+La ligne datée du jour est automatiquement ajoutée en tête de l’historique.
 
 Pour l'installation sur Rocky Linux, consultez [ce guide](docs/installation-rocky-linux.md).
 Un script `install.sh` est également fourni pour automatiser le déploiement ; il vous demandera notamment les chemins du certificat et de la clé privée si vous souhaitez activer HTTPS.

--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,8 @@
 Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **23 juillet 2025** : ajout du script `scripts/ajout_mise_a_jour.py` pour insérer automatiquement les entrées du journal.
+
 - **1 août 2025** : ajout sur la page principale d'une case affichant les informations réseau (opérateur, type et barres de signal).
 - **31 juillet 2025** : le script `install.sh` conserve désormais les paramètres
   saisis lors d'une précédente installation.

--- a/scripts/ajout_mise_a_jour.py
+++ b/scripts/ajout_mise_a_jour.py
@@ -1,0 +1,38 @@
+import argparse
+import datetime
+from pathlib import Path
+
+MONTHS_FR = [
+    "janvier", "février", "mars", "avril", "mai", "juin",
+    "juillet", "août", "septembre", "octobre", "novembre", "décembre"
+]
+
+def format_date_fr(date: datetime.date) -> str:
+    return f"{date.day} {MONTHS_FR[date.month - 1]} {date.year}"
+
+def insert_update_line(message: str, file_path: Path) -> None:
+    today = datetime.date.today()
+    date_fr = format_date_fr(today)
+    new_entry = f"- **{date_fr}** : {message}\n"
+
+    content = file_path.read_text().splitlines()
+    try:
+        idx = next(i for i, line in enumerate(content) if line.strip() == "## Historique")
+    except StopIteration:
+        raise RuntimeError("Section 'Historique' introuvable")
+
+    content.insert(idx + 1, new_entry)
+    file_path.write_text("\n".join(content) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Ajoute une ligne au journal des mises à jour")
+    parser.add_argument("message", help="Texte de la mise à jour")
+    args = parser.parse_args()
+
+    path = Path(__file__).resolve().parents[1] / "docs" / "mise-a-jour.md"
+    insert_update_line(args.message, path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Résumé
- ajouter `scripts/ajout_mise_a_jour.py` pour insérer une entrée datée dans `docs/mise-a-jour.md`
- documenter son utilisation dans le README
- créer un fichier `CONTRIBUTING.md` rappelant d'exécuter ce script et de commiter les modifications
- enregistrer cette nouveauté dans le journal des mises à jour

## Test
- `pytest -k ""`

------
https://chatgpt.com/codex/tasks/task_b_6880b3cea27c8322879f68ad257c6b7f