### PR TITLE
Correction du dernier expéditeur sur le tableau de bord

### DIFF
--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -4,6 +4,8 @@ Cette page recense les évolutions majeures de l'application. Elle doit être mi
 
 ## Historique
 - **23 juillet 2025** : ajout du script `scripts/ajout_mise_a_jour.py` pour insérer automatiquement les entrées du journal.
+- **23 juillet 2025** : correction d'un bug affichant toujours "N/A" pour le dernier expéditeur sur la page principale.
+- **24 juillet 2025** : utilisation du paramètre `timeout` lors de la récupération du dernier expéditeur afin de corriger l'affichage.
 
 - **1 août 2025** : ajout sur la page principale d'une case affichant les informations réseau (opérateur, type et barres de signal).
 - **31 juillet 2025** : le script `install.sh` conserve désormais les paramètres

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -114,11 +114,12 @@ class SMSHandler(BaseHTTPRequestHandler):
                 self.server.modem_url,
                 username=self.server.username,
                 password=self.server.password,
+                timeout=self.server.timeout,
             ) as connection:
                 client = Client(connection)
                 messages = list(client.sms.get_messages())
                 if messages:
-                    return messages[0]["Phone"]
+                    return messages[0].phone
         except Exception:
             pass
         return ""
@@ -210,6 +211,7 @@ class SMSHandler(BaseHTTPRequestHandler):
                 self.server.modem_url,
                 username=self.server.username,
                 password=self.server.password,
+                timeout=self.server.timeout,
             ) as connection:
                 client = Client(connection)
                 device_info = client.device.information()
@@ -387,6 +389,7 @@ class SMSHandler(BaseHTTPRequestHandler):
                 self.server.modem_url,
                 username=self.server.username,
                 password=self.server.password,
+                timeout=self.server.timeout,
             ) as connection:
                 client = Client(connection)
                 messages = [m.to_dict() for m in client.sms.get_messages()]
@@ -871,6 +874,7 @@ class SMSHandler(BaseHTTPRequestHandler):
                 self.server.modem_url,
                 username=self.server.username,
                 password=self.server.password,
+                timeout=self.server.timeout,
             ) as connection:
                 client = Client(connection)
                 for sms_id in ids:
@@ -933,6 +937,7 @@ class SMSHandler(BaseHTTPRequestHandler):
                 self.server.modem_url,
                 username=self.server.username,
                 password=self.server.password,
+                timeout=self.server.timeout,
             ) as connection:
                 client = Client(connection)
                 resp = client.sms.send_sms(recipients, text)


### PR DESCRIPTION
## Résumé
- prise en compte du délai `timeout` pour récupérer le dernier expéditeur
- même correction dans les actions liées aux SMS
- mise à jour du journal des mises à jour

## Tests
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6880b68e44148322b6ee8a949f86524f