### PR TITLE
Corrige l'endpoint /readsms

### DIFF
--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,8 @@
 Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **25 juillet 2025** : correction de l'endpoint `/readsms` qui accepte
+  désormais le paramètre `json` avec n'importe quelle valeur.
 - **23 juillet 2025** : ajout de la recherche de numéro via l'API Matrix sur la page /testsms
 
 - **23 juillet 2025** : install.sh n'affiche plus les questions si un fichier de configuration existe

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -400,7 +400,12 @@ class SMSHandler(BaseHTTPRequestHandler):
 
     def _serve_readsms(self):
         parsed = urllib.parse.urlparse(self.path)
-        want_json = parsed.query == "json" or "application/json" in self.headers.get("Accept", "")
+        params = urllib.parse.parse_qs(parsed.query)
+        want_json = (
+            "json" in params
+            or parsed.query == "json"
+            or "application/json" in self.headers.get("Accept", "")
+        )
 
         try:
             with Connection(


### PR DESCRIPTION
## Résumé
- accepte n'importe quelle valeur pour le paramètre `json`
- consigne la mise à jour dans le journal

## Test
- `python -m py_compile sms_api/*.py sms_http_api.py examples/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880d2f5a4cc8322bff11cc81248cfad