### PR TITLE
Correction crash /readsms si message vide

### DIFF
--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,8 @@
 Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **23 juillet 2025** : Correction d'un crash sur /readsms quand le contenu du SMS est vide
+
 - **25 juillet 2025** : correction de l'endpoint `/readsms` qui accepte
   désormais le paramètre `json` avec n'importe quelle valeur.
 

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -438,7 +438,7 @@ class SMSHandler(BaseHTTPRequestHandler):
                     f"{m['Index']}'></td>"
                     f"<td>{html.escape(m['Date'])}</td>"
                     f"<td>{html.escape(m['Phone'])}</td>"
-                    f"<td>{html.escape(m['Content'])}</td>"
+                    f"<td>{html.escape(m.get('Content') or '')}</td>"
                     "</tr>"
                 )
             )


### PR DESCRIPTION
## Summary
- empêcher l'appel à `html.escape` sur une valeur `None`
- consigner la correction dans le journal des mises à jour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880e175f9248322819ed2af06c35db0