### PR TITLE
Changement d'URL vers /sendsms et recherche Kafka

### DIFF
--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -4,8 +4,9 @@ Cette page recense les évolutions majeures de l'application. Elle doit être mi
 
 ## Historique
 
+- **24 juillet 2025** : Changement de l'URL `/testsms` vers `/sendsms` et ajout d'un bouton de recherche Kafka pour renseigner le destinataire
 - **23 juillet 2025** : Correction d'un crash sur /readsms quand le contenu du SMS est vide
-- **23 juillet 2025** : Ajout du support Kafka et d'une recherche de numéro dans /testsms
+- **23 juillet 2025** : Ajout du support Kafka et d'une recherche de numéro dans /sendsms
 - **23 juillet 2025** : correction de l'endpoint `/readsms` qui accepte
   désormais le paramètre `json` avec n'importe quelle valeur.
 - **23 juillet 2025** : install.sh n'affiche plus les questions si un fichier de configuration existe


### PR DESCRIPTION
## Résumé
- renommage de l'endpoint `/testsms` en `/sendsms`
- ajout d'une recherche Kafka dans la page d'envoi avec insertion du numéro
- mise à jour du journal des mises à jour

## Tests
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_6880e3db0fd08322a2b7f22fa6f86f68