### PR TITLE
Gestion de l'erreur Kafka lors de la recherche

### DIFF
--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -5,6 +5,7 @@ Cette page recense les évolutions majeures de l'application. Elle doit être mi
 ## Historique
 
 - **24 juillet 2025** : Changement de l'URL `/testsms` vers `/sendsms` et ajout d'un bouton de recherche Kafka pour renseigner le destinataire
+- **23 juillet 2025** : Gestion de l'erreur "NoBrokersAvailable" lors de la recherche Kafka
 - **23 juillet 2025** : Correction d'un crash sur /readsms quand le contenu du SMS est vide
 - **23 juillet 2025** : Ajout du support Kafka et d'une recherche de numéro dans /sendsms
 - **23 juillet 2025** : correction de l'endpoint `/readsms` qui accepte


### PR DESCRIPTION
## Résumé
- capture de l'exception `NoBrokersAvailable` dans `get_phone_from_kafka`
- ajout au journal des mises à jour

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880e6b5a208832288ff85ccb943ef1e