### PR TITLE
Ajoute bouton d'installation dans /admin

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -2,4 +2,5 @@
 
 - Modification des topics Kafka pour la recherche de numéro et mise à jour de la fonction get_phone_from_kafka.
 - Ajout de traces de log pour les requêtes Kafka.
+- Ajout d'un bouton d'installation sur /admin lançant install.sh puis redémarrant le service.
 

--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,8 @@
 Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **23 juillet 2025** : Ajout d'un bouton pour lancer install.sh depuis /admin
+
 
 - **24 juillet 2025** : Changement de l'URL `/testsms` vers `/sendsms` et ajout d'un bouton de recherche Kafka pour renseigner le destinataire
 - **23 juillet 2025** : Gestion de l'erreur "NoBrokersAvailable" lors de la recherche Kafka

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sqlite3
+import subprocess
 import urllib.parse
 from http.server import BaseHTTPRequestHandler
 import html
@@ -684,6 +685,7 @@ class SMSHandler(BaseHTTPRequestHandler):
                     <input type='text' name='kafka_cert' id='kafka_cert' class='form-control' value='{html.escape(cfg.get("kafka_cert", self.server.kafka_cert))}'>
                 </div>
                 <button type='submit' class='btn btn-company me-2'>Enregistrer</button>
+                <button type='button' class='btn btn-secondary me-2' onclick="fetch('/admin/install', {method:'POST'}).then(()=>alert('Installation...'))">Installer</button>
                 <button type='button' class='btn btn-danger' onclick="fetch('/admin/restart', {{method:'POST'}}).then(()=>alert('Redémarrage...'))">Redémarrer</button>
             </form>
             </div>
@@ -747,6 +749,21 @@ class SMSHandler(BaseHTTPRequestHandler):
         self.wfile.write(b'Redemarrage...')
         try:
             self.wfile.flush()
+        except Exception:
+            pass
+        self.server.restart()
+
+    def _install_and_restart(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b'Installation...')
+        try:
+            self.wfile.flush()
+        except Exception:
+            pass
+        script = os.path.join(os.path.dirname(__file__), os.pardir, 'install.sh')
+        try:
+            subprocess.run(['bash', script], check=True)
         except Exception:
             pass
         self.server.restart()
@@ -1018,6 +1035,9 @@ class SMSHandler(BaseHTTPRequestHandler):
             return
         if path == "/admin/restart":
             self._restart_service()
+            return
+        if path == "/admin/install":
+            self._install_and_restart()
             return
         if path != "/sms":
 


### PR DESCRIPTION
## Résumé
- ajoute un bouton `Installer` dans l'interface d'administration
- exécute `install.sh` puis redémarre le service
- documente la nouveauté dans `MISES_A_JOUR.md` et `docs/mise-a-jour.md`

## Tests
- `pytest -q`
- `python -m compileall -q sms_api/handler.py`


------
https://chatgpt.com/codex/tasks/task_b_6880fa23f75c8322a107a6934dcb95be