### PR TITLE
Fix Kafka consumer hang with timeout

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -3,3 +3,4 @@
 - Modification des topics Kafka pour la recherche de numéro et mise à jour de la fonction get_phone_from_kafka.
 - Ajout de traces de log pour les requêtes Kafka.
 
+- Ajout d'un timeout sur la consommation Kafka pour éviter le blocage lors de la recherche de numéro.

--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,8 @@
 Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **23 juillet 2025** : Ajout d'un timeout lors de la consommation Kafka pour éviter le blocage
+
 
 - **24 juillet 2025** : Changement de l'URL `/testsms` vers `/sendsms` et ajout d'un bouton de recherche Kafka pour renseigner le destinataire
 - **23 juillet 2025** : Gestion de l'erreur "NoBrokersAvailable" lors de la recherche Kafka

--- a/sms_api/utils.py
+++ b/sms_api/utils.py
@@ -156,6 +156,9 @@ def get_phone_from_kafka(baudin_id: str, cfg: dict) -> str:
             **common,
             value_deserializer=lambda v: v.decode("utf-8"),
             auto_offset_reset="latest",
+            # Stop iteration after 1s if no message was received so we can
+            # exit the loop when the timeout is reached
+            consumer_timeout_ms=1000,
         )
     except NoBrokersAvailable:
         logger.error("Aucun broker Kafka disponible")


### PR DESCRIPTION
## Summary
- add a `consumer_timeout_ms` in `get_phone_from_kafka` to avoid hanging when no message is returned
- document the Kafka timeout update in `docs/mise-a-jour.md` and `MISES_A_JOUR.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6880f9f632f08322b77354d957702e99