### PR TITLE
Augmentation du délai kafka

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -5,3 +5,4 @@
 
 - Ajout d'un timeout sur la consommation Kafka pour éviter le blocage lors de la recherche de numéro.
 - Mise en place d'un correlation ID pour la recherche de numéro via Kafka.
+- Augmentation du délai d'attente pour la consommation Kafka.

--- a/sms_api/utils.py
+++ b/sms_api/utils.py
@@ -175,7 +175,7 @@ def get_phone_from_kafka(baudin_id: str, cfg: dict) -> str:
     producer.flush()
     logger.debug("Message envoyé pour %s", baudin_id.upper())
 
-    end = time.time() + 10
+    end = time.time() + 30
     for message in consumer:
         headers = dict(message.headers or [])
         msg_id = headers.get("correlation_id")


### PR DESCRIPTION
## Summary
- ajuster la durée maximale d'attente lors de la lecture des réponses dans `get_phone_from_kafka`
- documenter la modification dans `MISES_A_JOUR.md`

## Testing
- `tox -e py311 -q` *(échoue : tests introuvables)*

------
https://chatgpt.com/codex/tasks/task_b_688105cdc6488322a62cbde4b3e5f9f5