### PR TITLE
Ajout de traces de correlation ID dans les logs Kafka

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -6,3 +6,4 @@
 - Ajout d'un timeout sur la consommation Kafka pour éviter le blocage lors de la recherche de numéro.
 - Mise en place d'un correlation ID pour la recherche de numéro via Kafka.
 - Augmentation du délai d'attente pour la consommation Kafka.
+- Ajout des traces du correlation ID dans les logs Kafka pour le debug du topic "sms reply".

--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -8,6 +8,7 @@ Cette page recense les évolutions majeures de l'application. Elle doit être mi
 
 
 - **24 juillet 2025** : Changement de l'URL `/testsms` vers `/sendsms` et ajout d'un bouton de recherche Kafka pour renseigner le destinataire
+- **24 juillet 2025** : Ajout des traces du correlation ID dans les logs Kafka pour le debug du topic "sms reply"
 - **23 juillet 2025** : Gestion de l'erreur "NoBrokersAvailable" lors de la recherche Kafka
 - **23 juillet 2025** : Correction d'un crash sur /readsms quand le contenu du SMS est vide
 - **23 juillet 2025** : Ajout du support Kafka et d'une recherche de numéro dans /sendsms


### PR DESCRIPTION
## Résumé
- log supplémentaire du `correlation_id` lors de l'envoi du message Kafka
- log du `correlation_id` reçu sur le topic de réponse pour faciliter le débogage
- mise à jour des journaux de modifications

## Tests
- `pytest -q`
- `tox -q` *(échoue : lint et tests introuvables)*

------
https://chatgpt.com/codex/tasks/task_b_688120e50aa8832290e77d6f56ce5650