### PR TITLE
Mise à jour de la recherche Baudin sur /sendsms

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -7,3 +7,4 @@
 - Mise en place d'un correlation ID pour la recherche de numéro via Kafka.
 - Augmentation du délai d'attente pour la consommation Kafka.
 - Ajout des traces du correlation ID dans les logs Kafka pour le debug du topic "sms reply".
+- Nouvelle disposition de la recherche via l'identifiant Baudin sur la page `/sendsms`.

--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,7 @@
 Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **25 juillet 2025** : La recherche par identifiant Baudin est déplacée dans une section repliable sur la page `/sendsms`.
 - **23 juillet 2025** : Mise en place d'un correlation ID pour la recherche de numéro via Kafka
 - **23 juillet 2025** : Ajout d'un timeout lors de la consommation Kafka pour éviter le blocage
 

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -571,23 +571,30 @@ class SMSHandler(BaseHTTPRequestHandler):
                     <input type='text' id='to' class='form-control' required>
                 </div>
                 <div class='mb-3'>
-                    <label for='baudinId' class='form-label'>Identifiant Baudin</label>
-                    <div class='input-group'>
-                        <input type='text' id='baudinId' class='form-control'>
-                        <button type='button' class='btn btn-secondary' onclick='searchBaudin()'>Rechercher</button>
-                    </div>
-                </div>
-                <div id='baudinResult' class='mb-3' style='display:none;'>
-                    <span id='foundPhone'></span>
-                    <button type='button' class='btn btn-company btn-sm ms-2' onclick='addPhone()'>Ajouter</button>
-                </div>
-                <div class='mb-3'>
                     <label for='text' class='form-label'>Message</label>
                     <textarea id='text' class='form-control' rows='4' required></textarea>
                 </div>
                 <div class='mb-3'>
                     <label for='apiKey' class='form-label'>Clé X-API-KEY</label>
                     <input type='text' id='apiKey' class='form-control'>
+                </div>
+                <button class='btn btn-link p-0 mb-3' type='button' data-bs-toggle='collapse' data-bs-target='#baudinSearch' aria-expanded='false' aria-controls='baudinSearch'>
+                    Recherche avancée via Kafka
+                </button>
+                <div class='collapse mb-3' id='baudinSearch'>
+                    <div class='card card-body'>
+                        <div class='mb-3'>
+                            <label for='baudinId' class='form-label'>Identifiant Baudin</label>
+                            <div class='input-group'>
+                                <input type='text' id='baudinId' class='form-control'>
+                                <button type='button' class='btn btn-secondary' onclick='searchBaudin()'>Rechercher</button>
+                            </div>
+                        </div>
+                        <div id='baudinResult' class='mb-3' style='display:none;'>
+                            <span id='foundPhone'></span>
+                            <button type='button' class='btn btn-company btn-sm ms-2' onclick='addPhone()'>Ajouter</button>
+                        </div>
+                    </div>
                 </div>
                 <button type='submit' class='btn btn-company'>Envoyer</button>
             </form>


### PR DESCRIPTION
## Résumé
- déplacement du champ de recherche par identifiant Baudin dans une section repliable
- mise à jour des journaux de modifications

## Tests
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6881236e41608322bbc8a2a74e53ceed