### PR TITLE
Ajout de vérification de mise à jour et affichage version

### DIFF
--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,7 @@
 Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **24 juillet 2025** : Affichage de la version courante dans le pied de page et vérification automatique des mises à jour.
 - **25 juillet 2025** : La recherche par identifiant Baudin est déplacée dans une section repliable sur la page `/sendsms`.
 - **23 juillet 2025** : Mise en place d'un correlation ID pour la recherche de numéro via Kafka
 - **23 juillet 2025** : Ajout d'un timeout lors de la consommation Kafka pour éviter le blocage

--- a/sms_api/utils.py
+++ b/sms_api/utils.py
@@ -13,6 +13,7 @@ __all__ = [
     "log_request",
     "validate_request",
     "get_last_update_date",
+    "get_current_version",
     "footer_html",
     "get_phone_from_kafka",
 ]
@@ -104,11 +105,29 @@ def get_last_update_date() -> str:
     return datetime.utcnow().strftime("%d/%m/%Y")
 
 
+def get_current_version() -> str:
+    """Récupère la version actuelle du paquet."""
+    path = os.path.join(
+        os.path.dirname(__file__), os.pardir, "huawei_lte_api", "__init__.py"
+    )
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                if "__version__" in line:
+                    m = re.search(r"'(.+?)'", line)
+                    if m:
+                        return m.group(1)
+    except Exception:
+        pass
+    return "N/A"
+
+
 def footer_html() -> str:
     date = get_last_update_date()
+    version = get_current_version()
     return (
         "<footer class='text-center mt-4'>"
-        f"Dernière mise à jour : {date} - &copy; DSI Baudinchateauneuf"
+        f"Dernière mise à jour : {date} - Version {version} - &copy; DSI Baudinchateauneuf"
         "</footer>"
     )
 


### PR DESCRIPTION
## Résumé
- affiche la version courante dans le pied de page
- ajoute un bouton d'alerte lorsque une mise à jour est disponible et permet de lancer `install.sh`
- journal des modifications mis à jour

## Tests
- `pytest -q`
- `python -m py_compile sms_api/utils.py sms_api/handler.py`


------
https://chatgpt.com/codex/tasks/task_b_6881dade03dc8322b6b3f65d4eb8db46