### PR TITLE
Amélioration connexion Kafka et mise à jour

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -15,3 +15,5 @@
 
 
 - Correction de la désérialisation des messages Kafka quand la valeur est nulle.
+- Connexion Kafka persistante lors du démarrage (sans bloquer si indisponible).
+- Correction du lancement de install.sh depuis le bouton de mise à jour.

--- a/sms_api/server.py
+++ b/sms_api/server.py
@@ -3,6 +3,9 @@ import os
 import sys
 import subprocess
 import shutil
+import logging
+
+from .utils import create_kafka_clients
 
 
 class SMSHTTPServer(HTTPServer):
@@ -46,6 +49,25 @@ class SMSHTTPServer(HTTPServer):
         self.kafka_ca_cert = kafka_ca_cert
         self.kafka_privkey = kafka_privkey
         self.kafka_cert = kafka_cert
+
+        self.kafka_producer = None
+        self.kafka_consumer = None
+        if self.kafka_url:
+            cfg = {
+                "kafka_client_id": self.kafka_client_id,
+                "kafka_url": self.kafka_url,
+                "kafka_group_id": self.kafka_group_id,
+                "kafka_username": self.kafka_username,
+                "kafka_password": self.kafka_password,
+                "kafka_ca_cert": self.kafka_ca_cert,
+                "kafka_privkey": self.kafka_privkey,
+                "kafka_cert": self.kafka_cert,
+            }
+            self.kafka_producer, self.kafka_consumer = create_kafka_clients(cfg)
+            if self.kafka_producer is None:
+                logging.getLogger(__name__).warning(
+                    "Impossible de se connecter à Kafka, la fonctionnalité sera desactivée"
+                )
 
     def restart(self):
         """Redémarre le service ou le processus."""


### PR DESCRIPTION
## Résumé
- connexion Kafka initialisée au démarrage du serveur
- utilisation de cette connexion pour rechercher les numéros
- correction du chemin utilisé pour lancer `install.sh`
- mise à jour du journal des changements

## Tests
- `tox -qq` *(échoue : tests introuvables)*

------
https://chatgpt.com/codex/tasks/task_b_6881fca2dea083228a24e385cf14732f