### PR TITLE
Mise à jour de la connexion Kafka

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -17,3 +17,4 @@
 - Correction de la désérialisation des messages Kafka quand la valeur est nulle.
 - Connexion Kafka persistante lors du démarrage (sans bloquer si indisponible).
 - Correction du lancement de install.sh depuis le bouton de mise à jour.
+- Allongement du session_timeout_ms à 30 minutes et envoi d'un heartbeat Kafka toutes les 10 minutes.


### PR DESCRIPTION
## Résumé
- prolongation du `session_timeout_ms` à 30 minutes
- envoi d'un heartbeat toutes les 10 minutes grâce à un thread
- mise à jour du fichier des mises à jour

## Tests
- `python -m py_compile sms_api/utils.py`

------
https://chatgpt.com/codex/tasks/task_b_688206acf128832285c4c7ddd573be2c