### PR TITLE
Ajout d'une colonne de recherche de groupe

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -18,3 +18,4 @@
 - Connexion Kafka persistante lors du démarrage (sans bloquer si indisponible).
 - Correction du lancement de install.sh depuis le bouton de mise à jour.
 - Allongement du session_timeout_ms à 30 minutes et envoi d'un heartbeat Kafka toutes les 10 minutes.
+- Réduction de la largeur de la carte de recherche avancée dans /sendsms et ajout d'un emplacement réservé pour la future recherche de groupes.

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -595,17 +595,26 @@ class SMSHandler(BaseHTTPRequestHandler):
                     🔎 Recherche avancée via Kafka
                 </button>
                 <div class='collapse mb-3' id='baudinSearch'>
-                    <div class='card card-body'>
-                        <div class='mb-3'>
-                            <label for='baudinId' class='form-label'>Identifiant Baudin</label>
-                            <div class='input-group'>
-                                <input type='text' id='baudinId' class='form-control'>
-                                <button type='button' class='btn btn-secondary' onclick='searchBaudin()'>Rechercher</button>
+                    <div class='row g-3'>
+                        <div class='col-md-6'>
+                            <div class='card card-body h-100'>
+                                <div class='mb-3'>
+                                    <label for='baudinId' class='form-label'>Identifiant Baudin</label>
+                                    <div class='input-group'>
+                                        <input type='text' id='baudinId' class='form-control'>
+                                        <button type='button' class='btn btn-secondary' onclick='searchBaudin()'>Rechercher</button>
+                                    </div>
+                                </div>
+                                <div id='baudinResult' class='mb-3' style='display:none;'>
+                                    <span id='foundPhone'></span>
+                                    <button type='button' class='btn btn-company btn-sm ms-2' onclick='addPhone()'>Ajouter</button>
+                                </div>
                             </div>
                         </div>
-                        <div id='baudinResult' class='mb-3' style='display:none;'>
-                            <span id='foundPhone'></span>
-                            <button type='button' class='btn btn-company btn-sm ms-2' onclick='addPhone()'>Ajouter</button>
+                        <div class='col-md-6'>
+                            <div class='card card-body h-100'>
+                                <p class='text-muted mb-0'>Recherche de groupe à venir...</p>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Résumé
- réduit la largeur de la carte existante dans `/sendsms`
- ajoute une seconde carte prévue pour la recherche de groupe
- documente la modification dans `MISES_A_JOUR.md`

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68821a96a0cc83228b128e6da5871162