### PR TITLE
Fix Kafka startup error

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -21,4 +21,5 @@
 - Réduction de la largeur de la carte de recherche avancée dans /sendsms et ajout d'un emplacement réservé pour la future recherche de groupes.
 - Ajout d'un paramètre request_timeout_ms pour éviter l'erreur lors du démarrage.
 - Ajout de traces de log pour le déclenchement de la mise à jour.
+- Définition de `delivery_timeout_ms` sur le producteur Kafka pour éviter l'erreur "delivery_timeout_ms higher than linger_ms + request_timeout_ms" lors du démarrage.
 

--- a/sms_api/utils.py
+++ b/sms_api/utils.py
@@ -189,6 +189,7 @@ def create_kafka_clients(cfg: dict):
             **common,
             value_serializer=lambda v: v.encode("utf-8"),
             request_timeout_ms=1900000,
+            delivery_timeout_ms=2000000,
         )
         consumer = KafkaConsumer(
             "matrix.person.phone-number.reply",


### PR DESCRIPTION
## Summary
- set `delivery_timeout_ms` higher than `request_timeout_ms`
- document the new timeout change in the changelog

## Testing
- `python -m py_compile sms_api/utils.py`
- `python -m py_compile sms_http_api.py`


------
https://chatgpt.com/codex/tasks/task_b_68821d767bec8322820d79861c6b037f