### PR TITLE
Fix premier message kafka

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -23,5 +23,6 @@
 - Ajout de traces de log pour le déclenchement de la mise à jour.
 - Définition de `delivery_timeout_ms` sur le producteur Kafka pour éviter l'erreur "delivery_timeout_ms higher than linger_ms + request_timeout_ms" lors du démarrage.
 - Augmentation de `connections_max_idle_ms` à 2 000 000 ms pour que la valeur soit supérieure à `request_timeout_ms`.
+- Forçage de l'adhésion au groupe Kafka lors de la création du consommateur afin de ne plus perdre le premier message.
 
 

--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,8 @@
 Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **24 juillet 2025** : Connexion Kafka join forcée au démarrage pour éviter la perte du premier message
+
 - **24 juillet 2025** : Ajout de traces de log pour le déclenchement de la mise à jour
 
 - **24 juillet 2025** : Utilisation des en-tetes kafka_correlationId, kafka_replyTopic et kafka_replyPartition

--- a/sms_api/utils.py
+++ b/sms_api/utils.py
@@ -206,6 +206,10 @@ def create_kafka_clients(cfg: dict):
             consumer_timeout_ms=1000,
         )
         _start_consumer_heartbeat(consumer)
+        try:
+            consumer.poll(0)
+        except Exception as exc:  # pragma: no cover - log seulement
+            logger.debug("Premiere poll Kafka en erreur: %s", exc)
 
         original_close = consumer.close
 


### PR DESCRIPTION
## Summary
- force initial poll to register Kafka consumer immediately
- update changelog
- document update

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68822087b6f4832283427be34bd9e621