### PR TITLE
Correction du démarrage du heartbeat Kafka

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -22,4 +22,5 @@
 - Ajout d'un paramètre request_timeout_ms pour éviter l'erreur lors du démarrage.
 - Ajout de traces de log pour le déclenchement de la mise à jour.
 - Définition de `delivery_timeout_ms` sur le producteur Kafka pour éviter l'erreur "delivery_timeout_ms higher than linger_ms + request_timeout_ms" lors du démarrage.
+- Correctif : lancement du heartbeat Kafka uniquement après un premier `poll(0)` du consommateur.
 

--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,7 @@
 Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **30 juillet 2025** : Lancement du heartbeat Kafka uniquement après un premier `poll(0)` du consommateur
 - **24 juillet 2025** : Ajout de traces de log pour le déclenchement de la mise à jour
 
 - **24 juillet 2025** : Utilisation des en-tetes kafka_correlationId, kafka_replyTopic et kafka_replyPartition

--- a/sms_api/utils.py
+++ b/sms_api/utils.py
@@ -202,6 +202,11 @@ def create_kafka_clients(cfg: dict):
             auto_offset_reset="latest",
             consumer_timeout_ms=1000,
         )
+        try:
+            consumer.poll(0)
+        except Exception as exc:  # pragma: no cover - log seulement
+            logger.debug("Première poll Kafka en erreur: %s", exc)
+
         _start_consumer_heartbeat(consumer)
 
         original_close = consumer.close


### PR DESCRIPTION
## Résumé
- appel initial à `poll(0)` avant de démarrer le thread de heartbeat Kafka
- mise à jour de la documentation des mises à jour

## Tests
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_688224ca5e748322a0748d855bd6520a