### PR TITLE
Fix Kafka idle timeout

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -23,4 +23,5 @@
 - Ajout de traces de log pour le déclenchement de la mise à jour.
 - Définition de `delivery_timeout_ms` sur le producteur Kafka pour éviter l'erreur "delivery_timeout_ms higher than linger_ms + request_timeout_ms" lors du démarrage.
 - Correctif : lancement du heartbeat Kafka uniquement après un premier `poll(0)` du consommateur.
+- Définition de `connections_max_idle_ms` pour éviter l'erreur de configuration au démarrage.
 

--- a/sms_api/utils.py
+++ b/sms_api/utils.py
@@ -188,6 +188,7 @@ def create_kafka_clients(cfg: dict):
         producer = KafkaProducer(
             **common,
             value_serializer=lambda v: v.encode("utf-8"),
+            connections_max_idle_ms=3000000,
             request_timeout_ms=1900000,
             delivery_timeout_ms=2000000,
         )
@@ -196,6 +197,7 @@ def create_kafka_clients(cfg: dict):
             group_id=cfg.get("kafka_group_id", "sms-consumer"),
             session_timeout_ms=1800000,
             heartbeat_interval_ms=600000,
+            connections_max_idle_ms=3000000,
             request_timeout_ms=1900000,
             **common,
             value_deserializer=lambda v: v.decode("utf-8") if v is not None else None,


### PR DESCRIPTION
## Summary
- avoid Kafka startup error by setting a longer `connections_max_idle_ms`
- note the change in the changelog

## Testing
- `tox -e py311` *(fails: file or directory not found: tests)*

------
https://chatgpt.com/codex/tasks/task_b_688225a8a7b88322842e18b8ae54c029