### PR TITLE
Warm up kafka on startup

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -25,3 +25,4 @@
 - Correctif : lancement du heartbeat Kafka uniquement après un premier `poll(0)` du consommateur.
 - Définition de `connections_max_idle_ms` pour éviter l'erreur de configuration au démarrage.
 
+- Pré-initialisation de la connexion Kafka en arrière-plan pour accélérer la première requête.

--- a/sms_api/server.py
+++ b/sms_api/server.py
@@ -68,6 +68,10 @@ class SMSHTTPServer(HTTPServer):
                 logging.getLogger(__name__).warning(
                     "Impossible de se connecter à Kafka, la fonctionnalité sera desactivée"
                 )
+            else:
+                from .utils import warmup_kafka
+
+                warmup_kafka(self.kafka_consumer)
 
     def restart(self):
         """Redémarre le service ou le processus."""

--- a/sms_api/utils.py
+++ b/sms_api/utils.py
@@ -227,6 +227,20 @@ def create_kafka_clients(cfg: dict):
         return None, None
 
 
+def warmup_kafka(consumer, timeout_ms=1000):
+    """Effectue un poll en tâche de fond pour établir la connexion."""
+
+    def _run():
+        try:
+            consumer.poll(timeout_ms=timeout_ms)
+        except Exception as exc:  # pragma: no cover - log seulement
+            logger.debug("Warmup Kafka en erreur: %s", exc)
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    return thread
+
+
 def get_phone_from_kafka(baudin_id: str, cfg: dict, *, producer=None, consumer=None) -> str:
     """Interroge Kafka pour obtenir le numéro associé à un identifiant."""
     if not cfg.get("kafka_url"):


### PR DESCRIPTION
## Summary
- warm up kafka connection to quickly join consumer group
- document kafka warmup in MISES_A_JOUR

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688227b29df88322b2f7bee264c8fb2a