### PR TITLE
Amélioration bouton Ajouter via Kafka

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -27,3 +27,4 @@
 
 - Pré-initialisation de la connexion Kafka en arrière-plan pour accélérer la première requête.
 - Correction de la pré-initialisation Kafka : plusieurs `poll` sont réalisés jusqu'à l'assignation des partitions.
+- Le bouton "Ajouter" de la recherche avancée via Kafka disparaît après avoir ajouté le numéro dans /sendsms.

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -531,9 +531,16 @@ class SMSHandler(BaseHTTPRequestHandler):
                         }
                         document.getElementById('foundPhone').textContent = phone;
                         document.getElementById('baudinResult').style.display = 'block';
+                        const btn = document.getElementById('addPhoneBtn');
+                        if (phone && phone !== 'Introuvable' && phone !== 'Erreur') {
+                            btn.style.display = 'inline-block';
+                        } else {
+                            btn.style.display = 'none';
+                        }
                     } catch(e) {
                         document.getElementById('foundPhone').textContent = 'Erreur';
                         document.getElementById('baudinResult').style.display = 'block';
+                        document.getElementById('addPhoneBtn').style.display = 'none';
                     }
                 }
 
@@ -546,6 +553,7 @@ class SMSHandler(BaseHTTPRequestHandler):
                     } else {
                         to.value = phone;
                     }
+                    document.getElementById('addPhoneBtn').style.display = 'none';
                 }
 
                 async function sendSms(event) {
@@ -610,7 +618,7 @@ class SMSHandler(BaseHTTPRequestHandler):
                                 </div>
                                 <div id='baudinResult' class='mb-3' style='display:none;'>
                                     <span id='foundPhone'></span>
-                                    <button type='button' class='btn btn-company btn-sm ms-2' onclick='addPhone()'>Ajouter</button>
+                                    <button type='button' id='addPhoneBtn' class='btn btn-company btn-sm ms-2' onclick='addPhone()'>Ajouter</button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Résumé
- rétablir le comportement du bouton "Ajouter" pour qu'il disparaisse après utilisation
- réaffichage automatique lors d'une nouvelle recherche
- mise à jour du fichier historique

## Test
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68822fb0f24c8322a6c9acd73b610635