### PR TITLE
Fix Kafka warmup when searching phone numbers

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -28,3 +28,4 @@
 - Pré-initialisation de la connexion Kafka en arrière-plan pour accélérer la première requête.
 - Correction de la pré-initialisation Kafka : plusieurs `poll` sont réalisés jusqu'à l'assignation des partitions.
 - Le bouton "Ajouter" de la recherche avancée via Kafka disparaît après avoir ajouté le numéro dans /sendsms.
+- Nouvelle tentative de warmup Kafka avant chaque recherche de numéro.

--- a/sms_api/utils.py
+++ b/sms_api/utils.py
@@ -260,6 +260,9 @@ def get_phone_from_kafka(baudin_id: str, cfg: dict, *, producer=None, consumer=N
         if producer is None or consumer is None:
             return ""
 
+    if not consumer.assignment():
+        warmup_kafka(consumer, timeout_ms=1000, max_attempts=20)
+
     correlation_id = str(uuid.uuid4())
     producer.send(
         "matrix.person.phone-number",


### PR DESCRIPTION
## Summary
- retry Kafka warmup if the consumer has no partition assignment when searching
- document the change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6882376e3c408322a7f38972bad0552c