### PR TITLE
Fix initial Kafka consumer lag

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -29,3 +29,4 @@
 - Correction de la pré-initialisation Kafka : plusieurs `poll` sont réalisés jusqu'à l'assignation des partitions.
 - Le bouton "Ajouter" de la recherche avancée via Kafka disparaît après avoir ajouté le numéro dans /sendsms.
 - Nouvelle tentative de warmup Kafka avant chaque recherche de numéro.
+- Positionnement du consommateur Kafka en fin de partition lors du warmup pour ignorer les anciens messages.

--- a/sms_api/utils.py
+++ b/sms_api/utils.py
@@ -239,6 +239,13 @@ def warmup_kafka(consumer, *, timeout_ms=1000, max_attempts=5):
                 logger.debug("Warmup Kafka en erreur: %s", exc)
             attempts += 1
 
+        try:
+            parts = consumer.assignment()
+            if parts:
+                consumer.seek_to_end(*parts)
+        except Exception as exc:  # pragma: no cover - log seulement
+            logger.debug("Seek_to_end en erreur: %s", exc)
+
     thread = threading.Thread(target=_run, daemon=True)
     thread.start()
     return thread


### PR DESCRIPTION
## Summary
- skip old Kafka messages by seeking to the end of partitions after warmup
- log update in `MISES_A_JOUR.md`

## Testing
- `pytest -q`
- `flake8 sms_api/utils.py`

------
https://chatgpt.com/codex/tasks/task_b_68823bc4ddbc8322a2ac259132e4d46f