### PR TITLE
Correction du warmup Kafka

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -29,3 +29,4 @@
 - Correction de la pré-initialisation Kafka : plusieurs `poll` sont réalisés jusqu'à l'assignation des partitions.
 - Le bouton "Ajouter" de la recherche avancée via Kafka disparaît après avoir ajouté le numéro dans /sendsms.
 - Nouvelle tentative de warmup Kafka avant chaque recherche de numéro.
+- Attente de l'assignation Kafka avant l'envoi.

--- a/sms_api/utils.py
+++ b/sms_api/utils.py
@@ -261,7 +261,14 @@ def get_phone_from_kafka(baudin_id: str, cfg: dict, *, producer=None, consumer=N
             return ""
 
     if not consumer.assignment():
-        warmup_kafka(consumer, timeout_ms=1000, max_attempts=20)
+        thread = warmup_kafka(consumer, timeout_ms=1000, max_attempts=20)
+        thread.join()
+        if not consumer.assignment():
+            logger.warning("Aucune partition assignée après le warmup Kafka")
+            if close_clients:
+                producer.close()
+                consumer.close()
+            return ""
 
     correlation_id = str(uuid.uuid4())
     producer.send(


### PR DESCRIPTION
## Résumé
- attente explicite de l'assignation Kafka avant l'envoi dans `get_phone_from_kafka`
- mise à jour du fichier `MISES_A_JOUR.md`

## Tests
- `python -m py_compile sms_api/utils.py`

------
https://chatgpt.com/codex/tasks/task_b_6882533538208322be81521448040c07