### PR TITLE
Mise à jour du warmup Kafka

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -32,3 +32,4 @@
 - Attente de l'assignation Kafka avant l'envoi.
 - Envoi du message même si aucune partition n'est assignée après le warmup Kafka.
 
+- Warmup Kafka bloquant au démarrage pour garantir l’assignation des partitions.

--- a/sms_api/server.py
+++ b/sms_api/server.py
@@ -71,7 +71,10 @@ class SMSHTTPServer(HTTPServer):
             else:
                 from .utils import warmup_kafka
 
-                warmup_kafka(self.kafka_consumer)
+                thread = warmup_kafka(
+                    self.kafka_consumer, timeout_ms=1000, max_attempts=20
+                )
+                thread.join()
 
     def restart(self):
         """Redémarre le service ou le processus."""


### PR DESCRIPTION
## Résumé
- blocage du warmup Kafka au démarrage
- mise à jour du fichier des modifications

## Tests
- `python -m py_compile sms_api/server.py`


------
https://chatgpt.com/codex/tasks/task_b_68825e750c448322b250e17d6437c0df