### PR TITLE
Réduction du warmup Kafka

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -32,3 +32,6 @@
 - Attente de l'assignation Kafka avant l'envoi.
 - Envoi du message même si aucune partition n'est assignée après le warmup Kafka.
 
+- Warmup Kafka bloquant au démarrage pour garantir l’assignation des partitions.
+- Augmentation du nombre d'essais du warmup Kafka pour fiabiliser la connexion.
+- Réduction du nombre d'essais du warmup Kafka pour accélérer le démarrage.

--- a/sms_api/server.py
+++ b/sms_api/server.py
@@ -71,7 +71,10 @@ class SMSHTTPServer(HTTPServer):
             else:
                 from .utils import warmup_kafka
 
-                warmup_kafka(self.kafka_consumer)
+                thread = warmup_kafka(
+                    self.kafka_consumer, timeout_ms=1000, max_attempts=10
+                )
+                thread.join()
 
     def restart(self):
         """Redémarre le service ou le processus."""

--- a/sms_api/utils.py
+++ b/sms_api/utils.py
@@ -261,7 +261,7 @@ def get_phone_from_kafka(baudin_id: str, cfg: dict, *, producer=None, consumer=N
             return ""
 
     if not consumer.assignment():
-        thread = warmup_kafka(consumer, timeout_ms=1000, max_attempts=20)
+        thread = warmup_kafka(consumer, timeout_ms=1000, max_attempts=10)
         thread.join()
         if not consumer.assignment():
             logger.warning("Aucune partition assignée après le warmup Kafka")


### PR DESCRIPTION
## Résumé
- warmup kafka bloquant ramené à 10s maximum pour ne pas ralentir le serveur
- mise à jour du fichier des modifications

## Tests
- `python -m py_compile sms_api/server.py`
- `python -m py_compile sms_api/utils.py`


------
https://chatgpt.com/codex/tasks/task_b_68825e750c448322b250e17d6437c0df