### PR TITLE
Mise à jour du thème et entête

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -30,3 +30,5 @@
 - Le bouton "Ajouter" de la recherche avancée via Kafka disparaît après avoir ajouté le numéro dans /sendsms.
 - Nouvelle tentative de warmup Kafka avant chaque recherche de numéro.
 - Positionnement du consommateur Kafka en fin de partition lors du warmup pour ignorer les anciens messages.
+- Les bandeaux d'en-tête utilisent 'bg-body-tertiary' pour s'adapter au mode sombre.
+- Sur la page /sendsms, l'entête indique maintenant 'Envoyer un SMS'.

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -341,7 +341,7 @@ class SMSHandler(BaseHTTPRequestHandler):
                     </div>
                 </div>
             </div>
-            <div class='p-5 mb-4 bg-light rounded-3 text-center'>
+            <div class='p-5 mb-4 bg-body-tertiary rounded-3 text-center'>
                 <h1 class='display-6 text-company mb-0'>Informations du modem</h1>
             </div>
             <div class='container'>
@@ -379,7 +379,7 @@ class SMSHandler(BaseHTTPRequestHandler):
             "<script>function selectAll(){document.querySelectorAll('.rowchk').forEach(c=>c.checked=true);}</script>",
             "</head><body class='container-fluid px-3 py-4'>",
             self._navbar_html(),
-            "<div class='p-5 mb-4 bg-light rounded-3 text-center'>",
+            "<div class='p-5 mb-4 bg-body-tertiary rounded-3 text-center'>",
             "<h1 class='display-6 text-company mb-0'>Historique des SMS</h1>",
             "</div>",
             "<div class='container'>",
@@ -464,7 +464,7 @@ class SMSHandler(BaseHTTPRequestHandler):
             "<script>function selectAll(){document.querySelectorAll('.rowchk').forEach(c=>c.checked=true);}</script>",
             "</head><body class='container-fluid px-3 py-4'>",
             self._navbar_html(),
-            "<div class='p-5 mb-4 bg-light rounded-3 text-center'>",
+            "<div class='p-5 mb-4 bg-body-tertiary rounded-3 text-center'>",
             "<h1 class='display-6 text-company mb-0'>SMS reçus</h1>",
             "</div>",
             "<div class='container'>",
@@ -585,8 +585,8 @@ class SMSHandler(BaseHTTPRequestHandler):
         </head>
         <body class='container-fluid px-3 py-4'>
             {NAVBAR}
-            <div class='p-5 mb-4 bg-light rounded-3 text-center'>
-                <h1 class='display-6 text-company mb-0'>Tester l\'envoi de SMS</h1>
+            <div class='p-5 mb-4 bg-body-tertiary rounded-3 text-center'>
+                <h1 class='display-6 text-company mb-0'>Envoyer un SMS</h1>
             </div>
             <div class='container'>
             <form id='smsForm' onsubmit='sendSms(event)' class='mb-3'>
@@ -662,7 +662,7 @@ class SMSHandler(BaseHTTPRequestHandler):
         </head>
         <body class='container-fluid px-3 py-4'>
             {self._navbar_html()}
-            <div class='p-5 mb-4 bg-light rounded-3 text-center'>
+            <div class='p-5 mb-4 bg-body-tertiary rounded-3 text-center'>
                 <h1 class='display-6 text-company mb-0'>Administration</h1>
             </div>
             <div class='container'>
@@ -848,7 +848,7 @@ class SMSHandler(BaseHTTPRequestHandler):
         </head>
         <body class='container-fluid px-3 py-4'>
             {NAVBAR}
-            <div class='p-5 mb-4 bg-light rounded-3 text-center'>
+            <div class='p-5 mb-4 bg-body-tertiary rounded-3 text-center'>
                 <h1 class='display-6 text-company mb-0'>Documentation de l\'API</h1>
             </div>
             <div class='container'>
@@ -927,7 +927,7 @@ class SMSHandler(BaseHTTPRequestHandler):
                       "<style>.bg-company{background-color:#0060ac;}.btn-company{background-color:#0060ac;border-color:#0060ac;}.text-company{color:#0060ac;}</style>",
                       "</head><body class='container-fluid px-3 py-4'>",
                       "{NAVBAR}",
-                      "<div class='p-5 mb-4 bg-light rounded-3 text-center'>",
+                      "<div class='p-5 mb-4 bg-body-tertiary rounded-3 text-center'>",
                       "<h1 class='display-6 text-company mb-0'>Journal des mises à jour</h1>",
                       "</div>",
                       "<div class='container'>"]


### PR DESCRIPTION
## Résumé
- utilisation de `bg-body-tertiary` pour les bandeaux de titre
- entête 'Envoyer un SMS' sur la page `/sendsms`
- mise à jour du fichier `MISES_A_JOUR.md`

## Tests
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68832bc74ee88322b523f6385b97339c