### PR TITLE
Fix update script to support non-interactive mode

### DIFF
--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,8 @@
 - Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **25 juillet 2025** : Ajout d'une option --yes pour l'installation non interactive
+
 - **30 juillet 2025** : Lancement du heartbeat Kafka uniquement après un premier `poll(0)` du consommateur
 - **30 juillet 2025** : Correction de la pré-initialisation Kafka (plusieurs `poll` jusqu'à l'assignation)
 - **24 juillet 2025** : Ajout de traces de log pour le déclenchement de la mise à jour

--- a/install.sh
+++ b/install.sh
@@ -5,13 +5,33 @@
 
 set -e
 
+NON_INTERACTIVE=false
+
+# Parse command line options
+while [[ "$1" == -* ]]; do
+    case "$1" in
+        -y|--yes)
+            NON_INTERACTIVE=true
+            shift
+            ;;
+        *)
+            echo "Option inconnue : $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
 # Prompt user for a value with an optional default.
 prompt_var() {
     local var_name=$1
     local prompt=$2
     local default=$3
     local input
-    read -r -p "$prompt [${default}]: " input
+    if [ "$NON_INTERACTIVE" = true ] || ! [ -t 0 ]; then
+        input=""
+    else
+        read -r -p "$prompt [${default}]: " input
+    fi
     if [ -z "$input" ]; then
         eval "$var_name=\"$default\""
     else
@@ -25,8 +45,12 @@ prompt_password_var() {
     local prompt=$2
     local default=$3
     local input
-    read -r -s -p "$prompt [${default}]: " input
-    echo
+    if [ "$NON_INTERACTIVE" = true ] || ! [ -t 0 ]; then
+        input=""
+    else
+        read -r -s -p "$prompt [${default}]: " input
+        echo
+    fi
     if [ -z "$input" ]; then
         eval "$var_name=\"$default\""
     else

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -822,7 +822,7 @@ class SMSHandler(BaseHTTPRequestHandler):
         script = os.path.abspath(script)
         logger.info("Lancement de la mise à jour avec %s", script)
         try:
-            subprocess.Popen(["bash", script], cwd=os.path.dirname(script))
+            subprocess.Popen(["bash", script, "--yes"], cwd=os.path.dirname(script))
             logger.info("Script de mise à jour démarré")
             self._send_json(200, {"status": "started"})
         except Exception as exc:


### PR DESCRIPTION
## Summary
- add `--yes` option to `install.sh` for unattended execution
- start update with this option
- document the change in the update log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68832da3290483228c6b286afd735734