### PR TITLE
Revert "Fix Kafka consumer poll interval"

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -32,4 +32,3 @@
 - Positionnement du consommateur Kafka en fin de partition lors du warmup pour ignorer les anciens messages.
 - Les bandeaux d'en-tête utilisent 'bg-body-tertiary' pour s'adapter au mode sombre.
 - Sur la page /sendsms, l'entête indique maintenant 'Envoyer un SMS'.
-- Ajout du paramètre max_poll_interval_ms=1800000 sur le consommateur Kafka pour éviter l'avertissement 'Consumer poll timeout has expired'.

--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,8 +3,6 @@
 - Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
-- **25 juillet 2025** : Ajout de max_poll_interval_ms pour éviter l'avertissement 'Consumer poll timeout has expired'
-
 - **25 juillet 2025** : Ajout d'une option --yes pour l'installation non interactive
 
 - **30 juillet 2025** : Lancement du heartbeat Kafka uniquement après un premier `poll(0)` du consommateur

--- a/sms_api/utils.py
+++ b/sms_api/utils.py
@@ -197,7 +197,6 @@ def create_kafka_clients(cfg: dict):
             group_id=cfg.get("kafka_group_id", "sms-consumer"),
             session_timeout_ms=1800000,
             heartbeat_interval_ms=600000,
-            max_poll_interval_ms=1800000,
             connections_max_idle_ms=3000000,
             request_timeout_ms=1900000,
             **common,


### PR DESCRIPTION
Reverts greglg45/bc-api-sms#119
ne regle pas le probleme et une fois de plus empeche l'envoie correcte de message kafka