### PR TITLE
Ajout d'une recherche de numéro via API

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -32,3 +32,4 @@
 - Positionnement du consommateur Kafka en fin de partition lors du warmup pour ignorer les anciens messages.
 - Les bandeaux d'en-tête utilisent 'bg-body-tertiary' pour s'adapter au mode sombre.
 - Sur la page /sendsms, l'entête indique maintenant 'Envoyer un SMS'.
+- Ajout d'une recherche de numéro via une API externe configurable.

--- a/sms_api/external_api.py
+++ b/sms_api/external_api.py
@@ -1,0 +1,38 @@
+import requests
+
+
+def get_phone_from_api(initials: str, base_url: str, api_key: str | None = None) -> str:
+    """Récupère le numéro de téléphone d'un utilisateur via une API externe.
+
+    Args:
+        initials: Les initiales de l'utilisateur.
+        base_url: L'URL de base de l'API (sans slash final).
+        api_key: Optionnel, clé API à envoyer dans l'en-tête ``X-API-KEY``.
+
+    Returns:
+        Le numéro de téléphone ou une chaîne vide si introuvable ou en cas d'erreur.
+    """
+    if not base_url:
+        return ""
+
+    url = base_url.rstrip('/') + f"/matrix/api/persons/{initials}/phone-numbers"
+    headers = {}
+    if api_key:
+        headers["X-API-KEY"] = api_key
+
+    try:
+        resp = requests.get(url, headers=headers, timeout=5)
+        resp.raise_for_status()
+        data = resp.json()
+        if isinstance(data, list):
+            for item in data:
+                phone = item.get("phoneNumber")
+                if phone:
+                    return phone
+    except Exception:
+        return ""
+
+    return ""
+
+
+__all__ = ["get_phone_from_api"]

--- a/sms_api/server.py
+++ b/sms_api/server.py
@@ -30,6 +30,8 @@ class SMSHTTPServer(HTTPServer):
         kafka_ca_cert="",
         kafka_privkey="",
         kafka_cert="",
+        sms_api_url="",
+        sms_api_key="",
     ):
         super().__init__(server_address, handler_class)
         self.modem_url = modem_url
@@ -49,6 +51,8 @@ class SMSHTTPServer(HTTPServer):
         self.kafka_ca_cert = kafka_ca_cert
         self.kafka_privkey = kafka_privkey
         self.kafka_cert = kafka_cert
+        self.sms_api_url = sms_api_url
+        self.sms_api_key = sms_api_key
 
         self.kafka_producer = None
         self.kafka_consumer = None

--- a/sms_http_api.py
+++ b/sms_http_api.py
@@ -68,6 +68,8 @@ def main():
     parser.add_argument("--kafka-ca-cert", type=str, default=os.getenv("KAFKA_CA_CERT", ""))
     parser.add_argument("--kafka-privkey", type=str, default=os.getenv("KAFKA_PRIVKEY", ""))
     parser.add_argument("--kafka-cert", type=str, default=os.getenv("KAFKA_CERT", ""))
+    parser.add_argument("--sms-api-url", type=str, default=os.getenv("SMS_API_URL", ""))
+    parser.add_argument("--sms-api-key", type=str, default=os.getenv("SMS_API_EXT_KEY", ""))
 
     args = parser.parse_args()
 
@@ -94,6 +96,8 @@ def main():
     kafka_ca_cert = config.get("kafka_ca_cert", args.kafka_ca_cert)
     kafka_privkey = config.get("kafka_privkey", args.kafka_privkey)
     kafka_cert = config.get("kafka_cert", args.kafka_cert)
+    sms_api_url = config.get("sms_api_url", args.sms_api_url)
+    sms_api_key = config.get("sms_api_key", args.sms_api_key)
 
     server = SMSHTTPServer(
         (args.host, args.port),
@@ -115,6 +119,8 @@ def main():
         kafka_ca_cert=kafka_ca_cert,
         kafka_privkey=kafka_privkey,
         kafka_cert=kafka_cert,
+        sms_api_url=sms_api_url,
+        sms_api_key=sms_api_key,
     )
 
     if certfile and keyfile:


### PR DESCRIPTION
## Summary
- nouvelle fonction `get_phone_from_api` pour interroger une API externe
- ajout des paramètres `sms_api_url` et `sms_api_key` au serveur et au CLI
- prise en charge de ces paramètres dans l'interface d'administration
- nouveau point d'entrée `/phone_api` et intégration dans la page `/sendsms`
- mise à jour du fichier des mises à jour

## Testing
- `python -m py_compile sms_api/external_api.py sms_api/server.py sms_api/handler.py sms_http_api.py`

------
https://chatgpt.com/codex/tasks/task_b_6883522df5208322b11f2243dc48c4f7