### PR TITLE
Fix optional type annotation for Python 3.9

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -33,3 +33,4 @@
 - Les bandeaux d'en-tête utilisent 'bg-body-tertiary' pour s'adapter au mode sombre.
 - Sur la page /sendsms, l'entête indique maintenant 'Envoyer un SMS'.
 - Ajout d'une recherche de numéro via une API externe configurable.
+- Correction du typage de la fonction get_phone_from_api pour compatibilite Python 3.9.

--- a/sms_api/external_api.py
+++ b/sms_api/external_api.py
@@ -1,7 +1,8 @@
 import requests
+from typing import Optional
 
 
-def get_phone_from_api(initials: str, base_url: str, api_key: str | None = None) -> str:
+def get_phone_from_api(initials: str, base_url: str, api_key: Optional[str] = None) -> str:
     """Récupère le numéro de téléphone d'un utilisateur via une API externe.
 
     Args:


### PR DESCRIPTION
## Summary
- assure la compatibilité Python 3.9 pour `get_phone_from_api`
- documente cette correction dans `MISES_A_JOUR.md`

## Testing
- `python -m py_compile sms_api/external_api.py`


------
https://chatgpt.com/codex/tasks/task_b_688356268d1083228c651250c30e2b1b