### PR TITLE
Supprimer logs /sms_count

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -36,3 +36,4 @@
 - Correction du typage de la fonction get_phone_from_api pour compatibilite Python 3.9.
 - Ajout de traces de log lors des recherches de numéro via l'API externe.
 - Transformation en majuscule des initiales lors de la recherche via l'API
+- Suppression des entrées '/sms_count' dans les logs

--- a/docs/mise-a-jour.md
+++ b/docs/mise-a-jour.md
@@ -3,6 +3,8 @@
 - Cette page recense les évolutions majeures de l'application. Elle doit être mise à jour à chaque merge sur la branche `main`.
 
 ## Historique
+- **25 juillet 2025** : Suppression des entrées '/sms_count' dans les logs
+
 - **25 juillet 2025** : Transformation en majuscule des initiales lors de la recherche via l'API
 
 - **25 juillet 2025** : Ajout d'une option --yes pour l'installation non interactive

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -216,6 +216,12 @@ class SMSHandler(BaseHTTPRequestHandler):
     def _json_error(self, status, message):
         self._send_json(status, {"error": message})
 
+    def log_message(self, format, *args):
+        """Surcharge pour ignorer les requêtes trop fréquentes."""
+        if self.path.startswith("/sms_count"):
+            return
+        super().log_message(format, *args)
+
     def do_GET(self):
         path = urllib.parse.urlparse(self.path).path
 


### PR DESCRIPTION
## Résumé
- ne plus enregistrer les requêtes `/sms_count`
- mise à jour du journal des changements

## Tests
- `pytest -q`
- `python -m py_compile sms_api/handler.py`


------
https://chatgpt.com/codex/tasks/task_b_68837e4f13608322b77c6e5022c5eef2