### PR TITLE
Ajout de la variable environnement

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -42,3 +42,4 @@
 - Réactivation de la recherche de numéro via l'API sur la page `/sendsms`.
 - Ajout d'une option --fresh pour réinstaller complètement sans utiliser la configuration existante.
 - Sécurisation de la suppression du répertoire d'installation dans install.sh.
+- Saisie de l'"environnement" lors de l'installation et affichage dans l'en-tête.

--- a/install.sh
+++ b/install.sh
@@ -77,6 +77,7 @@ PORT="80"
 API_KEY=""
 CERTFILE=""
 KEYFILE=""
+ENVIRONNEMENT="production"
 
 # Install required packages if missing
 install_deps() {
@@ -164,6 +165,10 @@ setup_service() {
     if [ -n "$CERTFILE" ] && [ -n "$KEYFILE" ]; then
         https_args=" --certfile $CERTFILE --keyfile $KEYFILE"
     fi
+    local env_arg=""
+    if [ -n "$ENVIRONNEMENT" ]; then
+        env_arg=" --environment $ENVIRONNEMENT"
+    fi
     sudo tee /etc/systemd/system/bc-api-sms.service >/dev/null <<EOF
 [Unit]
 Description=bc-api-sms HTTP API
@@ -174,7 +179,7 @@ Type=simple
 WorkingDirectory=$INSTALL_DIR
 ExecStart=$INSTALL_DIR/venv/bin/python sms_http_api.py \
     $ROUTER_URL --username $ROUTER_USERNAME --password $ROUTER_PASSWORD \
-    --host $HOST --port $PORT$api_key_arg$https_args
+    --host $HOST --port $PORT$api_key_arg$https_args$env_arg
 Restart=on-failure
 
 [Install]
@@ -208,6 +213,7 @@ main() {
         prompt_var API_KEY "API key (blank to disable)" "$API_KEY"
         prompt_var CERTFILE "TLS certificate file (blank to disable HTTPS)" "$CERTFILE"
         prompt_var KEYFILE "TLS private key file" "$KEYFILE"
+        prompt_var ENVIRONNEMENT "Environnement" "$ENVIRONNEMENT"
     fi
 
     install_deps
@@ -244,6 +250,7 @@ PORT="$PORT"
 API_KEY="$API_KEY"
 CERTFILE="$CERTFILE"
 KEYFILE="$KEYFILE"
+ENVIRONNEMENT="$ENVIRONNEMENT"
 EOF
     sudo chmod 600 "$CONFIG_FILE"
 }

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -66,7 +66,7 @@ NAVBAR_TEMPLATE = """
         <button class='navbar-toggler' type='button' data-bs-toggle='offcanvas' data-bs-target='#menu' aria-controls='menu'>
           <span class='navbar-toggler-icon'></span>
         </button>
-        <span class='navbar-brand ms-2'>API SMS BC</span>
+        <span class='navbar-brand ms-2'>API SMS BC {ENV}</span>
         <button id='updateBtn' class='btn btn-link text-warning ms-auto me-2 d-none' onclick='promptUpdate()'>Mise à jour disponible</button>
         <button id='themeToggle' class='btn btn-link text-light' onclick='toggleTheme()'>🌙</button>
       </div>
@@ -162,6 +162,8 @@ class SMSHandler(BaseHTTPRequestHandler):
 
     def _navbar_html(self) -> str:
         badge = "<span id='smsBadge' class='badge bg-secondary ms-1'>-</span>"
+        env = html.escape(getattr(self.server, "environment", ""))
+        env_html = f"<span class='badge bg-light text-dark ms-1'>{env}</span>" if env else ""
         script = (
             "<script>"
             "async function updateSmsBadge(){try{const r=await fetch('/sms_count');"
@@ -174,7 +176,10 @@ class SMSHandler(BaseHTTPRequestHandler):
             "updateSmsBadge();setInterval(updateSmsBadge,5000);checkUpdate();"
             "</script>"
         )
-        return NAVBAR_TEMPLATE.replace("{SMS_BADGE}", badge) + script
+        return (
+            NAVBAR_TEMPLATE.replace("{SMS_BADGE}", badge).replace("{ENV}", env_html)
+            + script
+        )
 
     def _send_json(self, status, payload):
         body = json.dumps(payload).encode("utf-8")

--- a/sms_api/server.py
+++ b/sms_api/server.py
@@ -24,6 +24,7 @@ class SMSHTTPServer(HTTPServer):
         timeout=5,
         sms_api_url="",
         sms_api_key="",
+        environment="",
     ):
         super().__init__(server_address, handler_class)
         self.modem_url = modem_url
@@ -37,6 +38,7 @@ class SMSHTTPServer(HTTPServer):
         self.timeout = timeout
         self.sms_api_url = sms_api_url
         self.sms_api_key = sms_api_key
+        self.environment = environment
 
     def restart(self):
         """Redémarre le service ou le processus."""

--- a/sms_http_api.py
+++ b/sms_http_api.py
@@ -62,6 +62,12 @@ def main():
     )
     parser.add_argument("--sms-api-url", type=str, default=os.getenv("SMS_API_URL", ""))
     parser.add_argument("--sms-api-key", type=str, default=os.getenv("SMS_API_EXT_KEY", ""))
+    parser.add_argument(
+        "--environment",
+        type=str,
+        default=os.getenv("SMS_ENVIRONNEMENT", ""),
+        help="Nom de l'environnement à afficher dans l'interface",
+    )
 
     args = parser.parse_args()
 
@@ -82,6 +88,7 @@ def main():
     timeout = int(config.get("timeout", args.timeout))
     sms_api_url = config.get("sms_api_url", args.sms_api_url)
     sms_api_key = config.get("sms_api_key", args.sms_api_key)
+    environment = config.get("environment", args.environment)
 
     server = SMSHTTPServer(
         (args.host, args.port),
@@ -97,6 +104,7 @@ def main():
         timeout=timeout,
         sms_api_url=sms_api_url,
         sms_api_key=sms_api_key,
+        environment=environment,
     )
 
     # Attributs Kafka conservés pour compatibilité de l'interface d'administration


### PR DESCRIPTION
## Résumé
- ajout d'une variable `ENVIRONNEMENT` dans `install.sh`
- affichage de cette variable dans l'en-tête de l'interface Web
- passage du paramètre à `sms_http_api.py` et stockage dans `SMSHTTPServer`
- mise à jour du journal des modifications

## Tests
- `python3 -m compileall -q sms_http_api.py sms_api`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888d88d754883228250de3b93cb8a5a