### PR TITLE
Ajout protection /admin

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -45,3 +45,4 @@
 - Ajout de la variable d'environnement affichée dans le bandeau
 - Suppression des champs Kafka dans l'interface /admin.
 - Désactivation de la vérification automatique des mises à jour et ajout d'un bouton manuel.
+- Protection de l'interface /admin par un mot de passe généré lors de l'installation.

--- a/install.sh
+++ b/install.sh
@@ -77,6 +77,7 @@ PORT="80"
 API_KEY=""
 CERTFILE=""
 KEYFILE=""
+ADMIN_PASSWORD=""
 ENVIRONMENT="Production"
 
 # Install required packages if missing
@@ -175,7 +176,7 @@ Type=simple
 WorkingDirectory=$INSTALL_DIR
 ExecStart=$INSTALL_DIR/venv/bin/python sms_http_api.py \
     $ROUTER_URL --username $ROUTER_USERNAME --password $ROUTER_PASSWORD \
-    --host $HOST --port $PORT --env "$ENVIRONMENT"$api_key_arg$https_args
+    --host $HOST --port $PORT --env "$ENVIRONMENT" --admin-password $ADMIN_PASSWORD$api_key_arg$https_args
 Restart=on-failure
 
 [Install]
@@ -209,6 +210,8 @@ main() {
         prompt_var API_KEY "API key (blank to disable)" "$API_KEY"
         prompt_var CERTFILE "TLS certificate file (blank to disable HTTPS)" "$CERTFILE"
         prompt_var KEYFILE "TLS private key file" "$KEYFILE"
+        ADMIN_PASSWORD=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 16)
+        echo "Mot de passe administration : $ADMIN_PASSWORD"
         prompt_var ENVIRONMENT "Environnement" "$ENVIRONMENT"
     fi
 
@@ -246,6 +249,7 @@ PORT="$PORT"
 API_KEY="$API_KEY"
 CERTFILE="$CERTFILE"
 KEYFILE="$KEYFILE"
+ADMIN_PASSWORD="$ADMIN_PASSWORD"
 ENVIRONMENT="$ENVIRONMENT"
 EOF
     sudo chmod 600 "$CONFIG_FILE"

--- a/sms_api/handler.py
+++ b/sms_api/handler.py
@@ -137,6 +137,32 @@ class SMSHandler(BaseHTTPRequestHandler):
     def _serve_sms_count(self):
         self._send_json(200, {"count": self._get_sms_count()})
 
+    def _check_admin_auth(self) -> bool:
+        password = getattr(self.server, "admin_password", None)
+        if not password:
+            return True
+        auth = self.headers.get("Authorization")
+        if not auth or not auth.startswith("Basic "):
+            self.send_response(401)
+            self.send_header("WWW-Authenticate", 'Basic realm="Administration"')
+            self.end_headers()
+            return False
+        import base64
+
+        try:
+            user_pass = base64.b64decode(auth.split(" ", 1)[1]).decode("utf-8")
+        except Exception:
+            self.send_response(401)
+            self.send_header("WWW-Authenticate", 'Basic realm="Administration"')
+            self.end_headers()
+            return False
+        if user_pass != f"admin:{password}":
+            self.send_response(401)
+            self.send_header("WWW-Authenticate", 'Basic realm="Administration"')
+            self.end_headers()
+            return False
+        return True
+
     def _serve_phone_api(self):
         query = urllib.parse.urlparse(self.path).query
         params = urllib.parse.parse_qs(query)
@@ -643,6 +669,8 @@ class SMSHandler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def _serve_admin(self):
+        if not self._check_admin_auth():
+            return
         try:
             with open(self.server.config_path, encoding="utf-8") as f:
                 cfg = json.load(f)
@@ -718,6 +746,8 @@ class SMSHandler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def _save_admin(self):
+        if not self._check_admin_auth():
+            return
         content_length = int(self.headers.get('Content-Length', 0))
         body = self.rfile.read(content_length).decode('utf-8')
         params = urllib.parse.parse_qs(body)
@@ -751,6 +781,8 @@ class SMSHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def _restart_service(self):
+        if not self._check_admin_auth():
+            return
         self.send_response(200)
         self.end_headers()
         self.wfile.write(b'Redemarrage...')

--- a/sms_api/server.py
+++ b/sms_api/server.py
@@ -25,6 +25,7 @@ class SMSHTTPServer(HTTPServer):
         sms_api_url="",
         sms_api_key="",
         env="Production",
+        admin_password=None,
     ):
         super().__init__(server_address, handler_class)
         self.modem_url = modem_url
@@ -39,6 +40,7 @@ class SMSHTTPServer(HTTPServer):
         self.sms_api_url = sms_api_url
         self.sms_api_key = sms_api_key
         self.env = env
+        self.admin_password = admin_password
 
     def restart(self):
         """Redémarre le service ou le processus."""

--- a/sms_http_api.py
+++ b/sms_http_api.py
@@ -49,6 +49,12 @@ def main():
         help="Chemin de la clé privée TLS",
     )
     parser.add_argument(
+        "--admin-password",
+        type=str,
+        default=os.getenv("SMS_ADMIN_PASSWORD"),
+        help="Mot de passe pour accéder à /admin",
+    )
+    parser.add_argument(
         "--config",
         type=str,
         default="config.json",
@@ -84,6 +90,7 @@ def main():
     sms_api_url = config.get("sms_api_url", args.sms_api_url)
     sms_api_key = config.get("sms_api_key", args.sms_api_key)
     env = config.get("env", args.env)
+    admin_password = config.get("admin_password", args.admin_password)
 
     server = SMSHTTPServer(
         (args.host, args.port),
@@ -100,6 +107,7 @@ def main():
         sms_api_url=sms_api_url,
         sms_api_key=sms_api_key,
         env=env,
+        admin_password=admin_password,
     )
 
     # Attributs Kafka conservés pour compatibilité de l'interface d'administration


### PR DESCRIPTION
## Résumé
- mot de passe d'administration généré lors de `install.sh`
- ajout de l'option `--admin-password` dans `sms_http_api.py`
- prise en compte du mot de passe dans `SMSHTTPServer`
- contrôle d'accès pour `/admin` dans `SMSHandler`
- mise à jour du journal des changements

## Tests
- `python -m py_compile sms_http_api.py sms_api/*.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_688b7f8ab06083229e39b4c4b193e33b