### PR TITLE
Correction crash certificat manquant

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -46,3 +46,4 @@
 - Suppression des champs Kafka dans l'interface /admin.
 - Désactivation de la vérification automatique des mises à jour et ajout d'un bouton manuel.
 - Protection de l'interface /admin par un mot de passe généré lors de l'installation.
+- Correction du crash au démarrage lorsque le certificat TLS est manquant.

--- a/sms_http_api.py
+++ b/sms_http_api.py
@@ -120,7 +120,7 @@ def main():
     server.kafka_privkey = config.get("kafka_privkey", os.getenv("KAFKA_PRIVKEY", ""))
     server.kafka_cert = config.get("kafka_cert", os.getenv("KAFKA_CERT", ""))
 
-    if certfile and keyfile:
+    if certfile and keyfile and os.path.exists(certfile) and os.path.exists(keyfile):
         import ssl
 
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
@@ -128,6 +128,8 @@ def main():
         server.socket = context.wrap_socket(server.socket, server_side=True)
         protocol = "https"
     else:
+        if certfile or keyfile:
+            logging.warning("Certificat ou clé TLS introuvable, démarrage en HTTP")
         protocol = "http"
 
     logging.info("Serving on %s://%s:%s", protocol, args.host, args.port)


### PR DESCRIPTION
## Résumé
- évite le crash si les fichiers TLS n'existent pas
- mise à jour du journal des modifications

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688b830409fc83229857eed6d57efc71