### PR TITLE
Ajout d'un type SMS inconnu

### DIFF
--- a/MISES_A_JOUR.md
+++ b/MISES_A_JOUR.md
@@ -1,5 +1,6 @@
 # Historique des mises à jour
 
+- Ajout de la valeur `UNKNOWN` dans `TypeEnum` pour gérer les SMS de type inconnu.
 - Modification des topics Kafka pour la recherche de numéro et mise à jour de la fonction get_phone_from_kafka.
 - Ajout de traces de log pour les requêtes Kafka.
 

--- a/huawei_lte_api/enums/sms.py
+++ b/huawei_lte_api/enums/sms.py
@@ -51,6 +51,7 @@ class TypeEnum(enum.IntEnum):
     SINGLE = 1
     MULTIPART = 2
     UNICODE = 5  # Not sure
+    UNKNOWN = 6  # Type d'usage inconnu
     DELIVERY_CONFIRMATION_SUCCESS = 7
     DELIVERY_CONFIRMATION_FAILURE = 8
 

--- a/tests/test_sms_type_enum.py
+++ b/tests/test_sms_type_enum.py
@@ -1,0 +1,14 @@
+"""Tests pour l'énumération TypeEnum des SMS."""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from huawei_lte_api.enums.sms import TypeEnum
+
+
+def test_type_enum_unknown():
+    """Vérifie que la valeur inconnue est bien définie."""
+    assert TypeEnum.UNKNOWN == 6
+    assert TypeEnum(6) is TypeEnum.UNKNOWN
+


### PR DESCRIPTION
## Résumé
- prise en charge du type `UNKNOWN` dans `TypeEnum`
- couverture de test pour le nouveau type SMS
- mise à jour du journal des modifications

## Tests
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bad09a231c8322948dde5c134f0d54